### PR TITLE
Change confirm move settings from boolean to string to allow users select which board size they want to double tap 

### DIFF
--- a/lib/board/board.dart
+++ b/lib/board/board.dart
@@ -292,7 +292,7 @@ class _BoardState extends State<Board> {
   }
 
   bool boardIsLarge() {
-    if (widget.confirmTap == ConfirmMoves.disable) {
+    if (widget.confirmTap == ConfirmMoves.disable.value) {
       return false;
     }
 

--- a/lib/board/board.dart
+++ b/lib/board/board.dart
@@ -9,6 +9,7 @@ import 'package:wqhub/board/board_settings.dart';
 import 'package:wqhub/board/board_geometry.dart';
 import 'package:wqhub/board/coordinate_style.dart';
 import 'package:wqhub/board/positioned_point.dart';
+import 'package:wqhub/settings/confirm_moves.dart';
 import 'package:wqhub/wq/wq.dart' as wq;
 
 class Board extends StatefulWidget with BoardGeometry {
@@ -35,7 +36,7 @@ class Board extends StatefulWidget with BoardGeometry {
   final IMap<wq.Point, wq.Color> stones;
   final IMapOfSets<wq.Point, Annotation> annotations;
   final wq.Color? turn;
-  final bool confirmTap;
+  final String confirmTap;
 
   @override
   // ignore: library_private_types_in_public_api
@@ -264,7 +265,7 @@ class _BoardState extends State<Board> {
     if (event.buttons != kPrimaryButton) return;
     final wq.Point? p = widget.offsetPoint(event.localPosition);
     if (p == null) return;
-    if (widget.confirmTap && boardIsLarge()) {
+    if (boardIsLarge()) {
       if (widget.stones.containsKey(p)) {
         setState(() {
           confirmPoint = null;
@@ -290,7 +291,17 @@ class _BoardState extends State<Board> {
     }
   }
 
-  bool boardIsLarge() => widget.settings.visibleSize > 13;
+  bool boardIsLarge() {
+    if (widget.confirmTap == ConfirmMoves.disable) {
+      return false;
+    }
+
+    final int confirmMoveSize = int.parse(widget.confirmTap.split("x")[0]);
+    if (widget.settings.visibleSize >= confirmMoveSize) {
+      return true;
+    }
+    return false;
+  }
 
   void _onPointerHover(PointerHoverEvent event) {
     final p = widget.offsetPoint(event.localPosition);

--- a/lib/settings/appearance_settings_page.dart
+++ b/lib/settings/appearance_settings_page.dart
@@ -6,6 +6,7 @@ import 'package:wqhub/board/board_annotation.dart';
 import 'package:wqhub/board/board_settings.dart';
 import 'package:wqhub/board/coordinate_style.dart';
 import 'package:wqhub/settings/appearance_settings_list.dart';
+import 'package:wqhub/settings/confirm_moves.dart';
 import 'package:wqhub/settings/shared_preferences_inherited_widget.dart';
 import 'package:wqhub/window_class_aware_state.dart';
 import 'package:wqhub/wq/wq.dart' as wq;
@@ -74,7 +75,7 @@ class _AppearanceSettingsPageState
               ),
             ]),
           }),
-          confirmTap: false,
+          confirmTap: ConfirmMoves.disable.value,
         );
       },
     );

--- a/lib/settings/behavior_settings_page.dart
+++ b/lib/settings/behavior_settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:wqhub/settings/confirm_moves.dart';
 import 'package:wqhub/settings/shared_preferences_inherited_widget.dart';
 import 'package:wqhub/train/response_delay.dart';
 
@@ -19,11 +20,21 @@ class _BehaviourSettingsPageState extends State<BehaviourSettingsPage> {
           ListTile(
             title: const Text('Confirm moves'),
             subtitle: const Text(
-                'Double-tap to confirm moves on large boards to avoid misclicks'),
-            trailing: Switch(
+                'Double-tap to confirm moves on boards equal or bigger than select to avoid misclicks'),
+            trailing: DropdownButton<String>(
               value: context.settings.confirmMoves,
-              onChanged: (value) {
-                context.settings.confirmMoves = value;
+              items: ConfirmMoves.values.map((boardSize) {
+                return DropdownMenuItem<String>(
+                  value: boardSize.value,
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(boardSize.value),
+                  ),
+                );
+              }).toList(),
+              borderRadius: BorderRadius.circular(8),
+              onChanged: (String? boardSize) {
+                context.settings.confirmMoves = boardSize.toString();
                 setState(() {});
               },
             ),

--- a/lib/settings/behavior_settings_page.dart
+++ b/lib/settings/behavior_settings_page.dart
@@ -20,7 +20,7 @@ class _BehaviourSettingsPageState extends State<BehaviourSettingsPage> {
           ListTile(
             title: const Text('Confirm moves'),
             subtitle: const Text(
-                'Double-tap to confirm moves on boards equal or bigger than select to avoid misclicks'),
+                'Double-tap to confirm moves on boards equal or bigger than selected to avoid misclicks'),
             trailing: DropdownButton<String>(
               value: context.settings.confirmMoves,
               items: ConfirmMoves.values.map((boardSize) {

--- a/lib/settings/confirm_moves.dart
+++ b/lib/settings/confirm_moves.dart
@@ -1,0 +1,9 @@
+enum ConfirmMoves {
+  disable("disable"),
+  board_9x9("9x9"),
+  board_13x13("13x13"),
+  board_19x19("19x19");
+
+  final String value;
+  const ConfirmMoves(this.value);
+}

--- a/lib/settings/settings.dart
+++ b/lib/settings/settings.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wqhub/board/board_settings.dart';
 import 'package:wqhub/board/board_theme.dart';
+import 'package:wqhub/settings/confirm_moves.dart';
 import 'package:wqhub/train/response_delay.dart';
 
 class Settings {
@@ -47,12 +48,12 @@ class Settings {
       prefs.setInt(_boardEdgeLine, edgeLine.index);
 
   // Behaviour
-  bool get confirmMoves =>
-      prefs.getBool('$_behaviourKeyPrefix.confirm_moves') ??
-      (Platform.isAndroid || Platform.isIOS);
+  String get confirmMoves =>
+      prefs.getString('$_behaviourKeyPrefix.confirm_moves') ??
+      ConfirmMoves.disable.value;
 
-  set confirmMoves(bool val) =>
-      prefs.setBool('$_behaviourKeyPrefix.confirm_moves', val);
+  set confirmMoves(String val) =>
+      prefs.setString('$_behaviourKeyPrefix.confirm_moves', val);
 
   ResponseDelay get responseDelay => ResponseDelay.values[
       prefs.getInt('$_behaviourKeyPrefix.response_delay') ??


### PR DESCRIPTION
Implement this #28 

With this new settings the default option is "disabled" which means, there is no need to confirm a move.

Maybe an implementation for phone devices is required for default setting but personally I don't like having different default settings for each platform.

 