### PR TITLE
Fix #45: next button for topic puzzle

### DIFF
--- a/lib/train/tag_exam_page.dart
+++ b/lib/train/tag_exam_page.dart
@@ -20,6 +20,12 @@ class TagExamPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ranks = tag.ranks();
+    final currentIndex = ranks.indexWhere((rank) => 
+      rank.from == rankRange.from && rank.to == rankRange.to
+    );
+    final hasNextRank = currentIndex != -1 && currentIndex + 1 < ranks.length;
+
     return ExamPage(
       title: "Topic Exam",
       taskCount: taskCount,
@@ -29,6 +35,9 @@ class TagExamPage extends StatelessWidget {
       onPass: () => context.stats.incrementTagExamPassCount(tag, rankRange),
       onFail: () => context.stats.incrementTagExamFailCount(tag, rankRange),
       buildRedoPage: () => TagExamPage(tag: tag, rankRange: rankRange),
+      buildNextPage: hasNextRank 
+        ? () => TagExamPage(tag: tag, rankRange: ranks[currentIndex + 1])
+        : null,
     );
   }
 


### PR DESCRIPTION
Add next button for topic/tag section tsumegos.
<img width="320" height="320" alt="image" src="https://github.com/user-attachments/assets/a6e873f0-7989-4825-8783-db0bc92d6620" />

If last rank:
<img width="320" height="320" alt="image" src="https://github.com/user-attachments/assets/31a9df74-4324-4d09-8917-2299c4bdd829" />
