### PR TITLE
Placing stones with _onPointerUp instead of _onPointerDown

### DIFF
--- a/lib/board/board.dart
+++ b/lib/board/board.dart
@@ -316,7 +316,7 @@ class _BoardState extends State<Board> {
   void pointerHoverUpdate(PointerEvent event) {
     final p = widget.offsetPoint(event.localPosition);
 
-    if(confirmPoint != null){
+    if (confirmPoint != null) {
       setState(() {
         lastHoverPoint = null;
       });
@@ -343,10 +343,9 @@ class _BoardState extends State<Board> {
 
   void _onPointerHover(PointerHoverEvent event) {
     final p = widget.offsetPoint(event.localPosition);
-    if( p == confirmPoint){
+    if (p == confirmPoint) {
       lastHoverPoint = null;
-    } else if (p == lastHoverPoint || lastPointPressed != null)
-      return;
+    } else if (p == lastHoverPoint || lastPointPressed != null) return;
     pointerHoverUpdate(event);
   }
 

--- a/lib/board/board.dart
+++ b/lib/board/board.dart
@@ -46,6 +46,7 @@ class Board extends StatefulWidget with BoardGeometry {
 class _BoardState extends State<Board> {
   wq.Point? lastHoverPoint;
   wq.Point? confirmPoint;
+  wq.Point? lastPointPressed;
 
   @override
   void didUpdateWidget(covariant Board oldWidget) {
@@ -156,6 +157,7 @@ class _BoardState extends State<Board> {
       cursor: widget.cursor,
       onExit: _onPointerExit,
       child: Listener(
+        onPointerUp: _onPointerUp,
         onPointerDown: _onPointerDown,
         onPointerHover: _onPointerHover,
         child: SizedBox.square(
@@ -261,10 +263,22 @@ class _BoardState extends State<Board> {
     ];
   }
 
-  void _onPointerDown(PointerDownEvent event) {
-    if (event.buttons != kPrimaryButton) return;
+  void _onPointerUp(PointerUpEvent event) {
     final wq.Point? p = widget.offsetPoint(event.localPosition);
     if (p == null) return;
+
+    if (p != lastPointPressed) {
+      setState(() {
+        lastPointPressed = null;
+      });
+      pointerHoverUpdate(event);
+      return;
+    }
+
+    setState(() {
+      lastPointPressed = null;
+    });
+
     if (widget.confirmTap && boardIsLarge()) {
       if (widget.stones.containsKey(p)) {
         setState(() {
@@ -291,15 +305,23 @@ class _BoardState extends State<Board> {
     }
   }
 
-  bool boardIsLarge() {
-    final int confirmMoveboardSize = context.settings.confirmMovesBoardSize;
-    final int currentBoardSize = widget.settings.visibleSize;
-    return confirmMoveboardSize <= currentBoardSize;
+  void _onPointerDown(PointerDownEvent event) {
+    if (event.buttons != kPrimaryButton) return;
+    final wq.Point? p = widget.offsetPoint(event.localPosition);
+    setState(() {
+      lastPointPressed = p;
+    });
   }
 
-  void _onPointerHover(PointerHoverEvent event) {
+  void pointerHoverUpdate(PointerEvent event) {
     final p = widget.offsetPoint(event.localPosition);
-    if (p == lastHoverPoint || p == confirmPoint) return;
+
+    if(confirmPoint != null){
+      setState(() {
+        lastHoverPoint = null;
+      });
+    }
+
     if (p != null && widget.stones.containsKey(p)) {
       if (lastHoverPoint != null) {
         setState(() {
@@ -313,10 +335,31 @@ class _BoardState extends State<Board> {
     });
   }
 
+  bool boardIsLarge() {
+    final int confirmMoveboardSize = context.settings.confirmMovesBoardSize;
+    final int currentBoardSize = widget.settings.visibleSize;
+    return confirmMoveboardSize <= currentBoardSize;
+  }
+
+  void _onPointerHover(PointerHoverEvent event) {
+    final p = widget.offsetPoint(event.localPosition);
+    if( p == confirmPoint){
+      lastHoverPoint = null;
+    } else if (p == lastHoverPoint || lastPointPressed != null)
+      return;
+    pointerHoverUpdate(event);
+  }
+
   void _onPointerExit(PointerExitEvent event) {
     if (lastHoverPoint != null) {
       setState(() {
         lastHoverPoint = null;
+      });
+    }
+
+    if (lastPointPressed != null) {
+      setState(() {
+        lastPointPressed = null;
       });
     }
   }


### PR DESCRIPTION
Change behavior of placing stones according to issue #38 

- Create a variable flag (lastPointPressed) to track where left click is pressed in _onPointerDown.
- On left click released:
    - If the mouse is released on a different grid position from lastPointPressed, no stone is placed.
    - If mouse is release in the same grid position than lastPointPressed the previous behavior of _onPointerDown is executed.
- While left click is still pressed _onPointerHover will not update to allow players remember where they pressed before (in opposite of ogs where the "hover stone" always follow the mouse no matter what).
- Some adjustments have been made in _onPointerHover because _onPointerUp require a "hover stone" update when left click is released, previously only happen when you move the mouse.
- Previous unnoticed bug introduced on 0.18 with the setting of confirmMoves active where lastHoverPoint could coexist with a confirmpoint when you move the mouse inside a confirmpoint stone with a previously existing lastHoverPointis is fixed (basically you had 2 semi transparent stones together).


This is potentially an app breaking change if implemented poorly so I hope we can talk about if this place stone behavior make sense.