### PR TITLE
sgf: some tests and fixes

### DIFF
--- a/lib/parse/sgf/sgf.dart
+++ b/lib/parse/sgf/sgf.dart
@@ -30,7 +30,7 @@ class _SgfDefinition extends GrammarDefinition {
 
   Parser<SgfTree> gameTree() =>
       (ref0(nodeSeq) & ref0(gameTree).starSeparated(ref0(space)))
-          .skip(before: char('('), after: char(')'))
+          .skip(before: char('(').trim(), after: char(')').trim())
           .map((l) => SgfTree(
                 nodes: l[0],
                 children: l[1].elements,

--- a/lib/parse/sgf/sgf.dart
+++ b/lib/parse/sgf/sgf.dart
@@ -53,8 +53,12 @@ class _SgfDefinition extends GrammarDefinition {
   Parser<List<String>> propValues() =>
       ref0(propValue).plusSeparated(ref0(space)).map((sl) => sl.elements);
 
-  Parser<String> propValue() => (any().starLazy(char(']')).flatten())
-      .skip(before: char('['), after: char(']'));
+  Parser<String> propValue() =>
+      ((char('\\') & char(']')).map((_) => ']') // handle escaped ]
+          | (char(']').not() & any()).pick(1)) // any char except ]
+          .star()
+          .map((parts) => parts.join())
+          .skip(before: char('['), after: char(']'));
 
   Parser<void> space() => (whitespace() | newline()).star();
 }

--- a/test/sgf_test.dart
+++ b/test/sgf_test.dart
@@ -80,11 +80,33 @@ void main() {
     expect(rec.moves[0].col, wq.Color.black);
   });
 
-  test('fromSgf with variations... and a space', () {
-    const problematicSgfData =
+  test('parse with variations... and a space', () {
+    const sgfWithSpaceAroundVariation =
         '(;GM[1]FF[4]SZ[9];B[fe];W[de] (;B[ec];W[dc];B[db])(;B[ee];W[dd]))';
-    // TODO: we don't actually want this to throw an exception
-    expect(() => GameRecord.fromSgf(problematicSgfData),
-        throwsA(isA<Exception>()));
+    final sgf = Sgf.parse(sgfWithSpaceAroundVariation);
+    expect(sgf.trees.length, 1);
+
+    final tree = sgf.trees.first;
+    // Main line nodes: root + B[fe] + W[de]
+    expect(tree.nodes.length, 3);
+    expect(tree.nodes[0]['GM'], ['1']);
+    expect(tree.nodes[1]['B'], ['fe']);
+    expect(tree.nodes[2]['W'], ['de']);
+
+    // There are two variations (children)
+    expect(tree.children.length, 2);
+
+    // First variation
+    final var1 = tree.children[0];
+    expect(var1.nodes.length, 3);
+    expect(var1.nodes[0]['B'], ['ec']);
+    expect(var1.nodes[1]['W'], ['dc']);
+    expect(var1.nodes[2]['B'], ['db']);
+
+    // Second variation
+    final var2 = tree.children[1];
+    expect(var2.nodes.length, 2);
+    expect(var2.nodes[0]['B'], ['ee']);
+    expect(var2.nodes[1]['W'], ['dd']);
   });
 }


### PR DESCRIPTION
- A test for escaped `\]` handling (fixed)
- A test for variations (already worked)
- A test for variations and some whitespace (fixed)

Context: I'm feeding in an OGS SGF (for example: https://beta.online-go.com/api/v1/games/19097/sgf) and the parser completely barfs.

~~I'm not familiar with petitparser, and don't really know how to fix that whitespace issue.  Hopefully the test cases make it clear that there is a bug in the WeiqiHub parsing, not just weird OGS output.~~  This PR fixes https://github.com/ale64bit/WeiqiHub/issues/66.