### PR TITLE
Handle variations in GameRecord.fromSgf

### DIFF
--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -277,48 +277,9 @@ class OGSGameClient extends GameClient {
       }
 
       final sgfContent = response.body;
-      return _parseOgsSgf(sgfContent);
+      return GameRecord.fromSgf(sgfContent);
     } catch (e) {
       throw Exception('Failed to get game record: $e');
-    }
-  }
-
-  /// Parses OGS SGF files which structure moves as nested variations
-  /// instead of sequential nodes in the main line.
-  GameRecord _parseOgsSgf(String sgfStr) {
-    final sgf = Sgf.parse(sgfStr);
-    if (sgf.trees.isEmpty) throw const FormatException('Empty SGF');
-
-    final moves = <wq.Move>[];
-    _extractMovesFromOgsTree(sgf.trees.first, moves, isRoot: true);
-
-    return GameRecord(
-      moves: moves,
-      type: GameRecordType.sgf,
-      rawData: utf8.encode(sgfStr),
-    );
-  }
-
-  /// Recursively traverses the OGS SGF tree to extract moves.
-  /// OGS puts each move in its own variation, so we need to follow
-  /// the first variation at each level to get the main game line.
-  void _extractMovesFromOgsTree(SgfTree tree, List<wq.Move> moves,
-      {bool isRoot = false}) {
-    // Process nodes in the current tree level
-    // Skip root node only for the initial tree, not for variations
-    final nodesToProcess = isRoot ? tree.nodes.skip(1) : tree.nodes;
-    for (final node in nodesToProcess) {
-      if (node.containsKey('B')) {
-        moves.add((col: wq.Color.black, p: wq.parseSgfPoint(node['B']!.first)));
-      } else if (node.containsKey('W')) {
-        moves.add((col: wq.Color.white, p: wq.parseSgfPoint(node['W']!.first)));
-      }
-    }
-
-    // OGS typically puts the next move in the first variation
-    // Follow the first child if it exists
-    if (tree.children.isNotEmpty) {
-      _extractMovesFromOgsTree(tree.children.first, moves);
     }
   }
 

--- a/test/sgf_test.dart
+++ b/test/sgf_test.dart
@@ -64,6 +64,12 @@ void main() {
     expect(var2.nodes.length, 2);
     expect(var2.nodes[0]['B'], ['ee']);
     expect(var2.nodes[1]['W'], ['dd']);
+
+    final rec = GameRecord.fromSgf(sgfData);
+    // We assume the actual game follows the first variation
+    // at each branch point.  Therefore, we have
+    // 2 moves at the top level + 3 moves in the first variation.
+    expect(rec.moves.length, 5);
   });
 
   test('SGF with escaped bracket', () {


### PR DESCRIPTION
This allows us to use GameRecord.fromSgf for OGS
files, which uses parentheses for every move, even the moves on the trunk branch.