### PR TITLE
Fix passes and better logging

### DIFF
--- a/lib/game_client/ogs/ogs_game.dart
+++ b/lib/game_client/ogs/ogs_game.dart
@@ -96,6 +96,13 @@ class OGSGame extends Game {
   void _handleMessage(Map<String, dynamic> message) {
     final event = message['event'] as String;
 
+    // Check if this is an error event for our game
+    if (event == 'game/$id/error') {
+      final data = message['data'];
+      _logger.warning('Error received for game $id: $data');
+      return;
+    }
+
     // Check if this is a move event for our game
     if (event == 'game/$id/move') {
       final data = message['data'] as Map<String, dynamic>;

--- a/lib/game_client/ogs/ogs_game.dart
+++ b/lib/game_client/ogs/ogs_game.dart
@@ -66,7 +66,8 @@ class OGSGame extends Game {
 
   @override
   Future<void> pass() {
-    return _sendMove('', myColor);
+    // ".." isn't standard SGF format, but it's what OGS expects for a pass
+    return _sendMove('..', myColor);
   }
 
   Future<void> _sendMove(String sgfMove, wq.Color color) {
@@ -126,6 +127,11 @@ class OGSGame extends Game {
         point = (row, col);
       } else {
         _logger.severe('Unknown move format: $moveData');
+        return;
+      }
+
+      if (point == (-1, -1)) {
+        _moveController.add(null);
         return;
       }
 

--- a/lib/game_client/ogs/ogs_websocket_manager.dart
+++ b/lib/game_client/ogs/ogs_websocket_manager.dart
@@ -148,15 +148,13 @@ class OGSWebSocketManager {
         // Emit the message to listeners
         _messageController.add({
           'event': command,
-          'data': payload ?? {},
+          'data': payload,
           'request_id': requestId,
         });
-        
-        _handleSpecialEvents(command, payload ?? {});
       }
       
     } catch (e) {
-      _log.warning('Error parsing message: $e');
+      _log.warning('Error parsing message \'$message\': $e');
     }
   }
   
@@ -170,26 +168,6 @@ class OGSWebSocketManager {
       _clockDrift = now - _latency / 2 - serverTime;
       
       _log.fine('Latency: ${_latency}ms, Clock drift: ${_clockDrift}ms');
-    }
-  }
-  
-  void _handleSpecialEvents(String event, Map<String, dynamic> data) {
-    switch (event) {
-      case 'authenticated':
-        _log.info('Successfully authenticated with OGS');
-        break;
-      case 'authentication_failed':
-        _log.warning('Authentication failed: ${data['error']}');
-        break;
-      case 'game/move':
-        _log.fine('Game move received: $data');
-        break;
-      case 'game/data':
-        _log.fine('Game data received: $data');
-        break;
-      case 'error':
-        _log.warning('Server error: $data');
-        break;
     }
   }
   


### PR DESCRIPTION
I didn't test `pass` in my last PR apparently 😅 This diff fixes passes in both directions, and adds better error messages too.

Testing:

https://github.com/user-attachments/assets/dd7eacb8-9f76-4e90-aa03-266f68ab1c9f

and clearer error messages.  Examples (which have since been resolved):

```
[log] WARNING: 2025-09-15 19:33:22.279936: [OGSWebSocketManager] Error parsing message '["game/19181/error","Error: Invalid move: last_move 1 G7. Player to move: white 1300"]': type 'String' is not a subtype of type 'Map<String, dynamic>'
```

or

```
[log] WARNING: 2025-09-15 19:50:36.705587: [OGSGame] Error received for game 19184: Error: Invalid move:  last_move 3 E7. Player to move:  white 1300
```