### PR TITLE
[ogs] 2-way socket communication

### DIFF
--- a/lib/game_client/ogs/ogs_game.dart
+++ b/lib/game_client/ogs/ogs_game.dart
@@ -70,17 +70,19 @@ class OGSGame extends Game {
     return _sendMove('..', myColor);
   }
 
-  Future<void> _sendMove(String sgfMove, wq.Color color) {
-    // Note: OGS Websocket supports 2-way communication if one appends a requestId
-    // we could potentially wait for confirmation of the move being accepted
-    _webSocketManager.send('game/move', {
-      'game_id': int.parse(id),
-      'move': sgfMove,
-    });
+  Future<void> _sendMove(String sgfMove, wq.Color color) async {
+    try {
+      await _webSocketManager.sendAndGetResponse('game/move', {
+        'game_id': int.parse(id),
+        'move': sgfMove,
+      });
 
-    _logger.fine('Sent move "$sgfMove" for game $id');
-
-    return Future.value();
+      _logger
+          .fine('Move "$sgfMove" for game $id confirmed by server');
+    } catch (error) {
+      _logger.warning('Failed to send move "$sgfMove" for game $id: $error');
+      rethrow;
+    }
   }
 
   @override


### PR DESCRIPTION
This gives us some confirmation that moves were received by the server.  [related comment](https://github.com/ale64bit/WeiqiHub/pull/72#discussion_r2346548397)

Note: I wasn't able to trigger error messages, which I think is a flaw in the OGS API, but I am following the source at [GobanSocket.ts](https://github.com/online-go/goban/blob/6e9d7cfb407ff6192ba56471447f4e361f03ef11/src/engine/GobanSocket.ts#L302) and [docs](https://docs.online-go.com/goban/modules/protocol.html).

testing:

```
[log] FINE: 2025-09-16 21:33:09.871252: [OGSWebSocketManager] Received: [1,null,null]
[log] FINE: 2025-09-16 21:33:09.871722: [OGSGame] Move "ff" for game 19195 confirmed by server
[log] FINE: 2025-09-16 21:33:20.016160: [OGSWebSocketManager] Received: [2,null,null]
[log] FINE: 2025-09-16 21:33:20.016395: [OGSGame] Move ".." for game 19195 confirmed by server
```