### PR TITLE
Add Flutter 3.32 to PR checks

### DIFF
--- a/.github/workflows/community_ci.yaml
+++ b/.github/workflows/community_ci.yaml
@@ -22,8 +22,16 @@ on:
 
 jobs:
   test:
-    name: "Static Analysis & Tests"
+    name: "Static Analysis & Tests (${{ matrix.flutter-name }})"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # File picker is broken on Flutter 3.33 on Windows
+          - flutter-version: '3.32.0'
+            flutter-name: 'Flutter 3.32'
+          - flutter-version: ''
+            flutter-name: 'Latest Stable'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -32,10 +40,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: ${{ matrix.flutter-version }}
           
       - name: Install Flutter dependencies
         run: flutter pub get
-        
+
       - name: Analyze code
         run: flutter analyze
         


### PR DESCRIPTION
Windows builds are stuck on an old version of Flutter due to file picker constraints (see related commit https://github.com/ale64bit/WeiqiHub/commit/a080747480dcfeba9af4777b2d638891d2ab3f0c)

Let's use this version in the PR checks.