### PR TITLE
Test OGSWebsocketManager.sendAndGetResponse

### DIFF
--- a/lib/game_client/ogs/ogs_websocket_manager.dart
+++ b/lib/game_client/ogs/ogs_websocket_manager.dart
@@ -14,7 +14,7 @@ class OGSWebSocketManager {
 
   StreamChannel? _channel;
   final String serverUrl;
-  final StreamChannel Function(Uri) _createChannel;
+  final StreamChannel Function(Uri) createChannel;
   String? _deviceId;
 
   final ValueNotifier<bool> _connected = ValueNotifier(false);
@@ -36,8 +36,8 @@ class OGSWebSocketManager {
 
   OGSWebSocketManager({
     required this.serverUrl,
-    StreamChannel Function(Uri)? createChannel,
-  }) : _createChannel = createChannel ?? WebSocketChannel.connect {
+    this.createChannel = WebSocketChannel.connect,
+  }) {
     _generateDeviceId();
   }
 
@@ -63,7 +63,7 @@ class OGSWebSocketManager {
 
       _log.fine('Connecting to OGS WebSocket: $wsUrl');
 
-      _channel = _createChannel(Uri.parse(wsUrl));
+      _channel = createChannel(Uri.parse(wsUrl));
 
       _channel!.stream.listen(
         _handleMessage,

--- a/test/ogs_websocket_test.dart
+++ b/test/ogs_websocket_test.dart
@@ -16,9 +16,14 @@ void main() {
       final mockChannel =
           StreamChannel(serverToClient.stream, clientToServer.sink);
 
-      // Create the manager and set the mock channel
-      final manager = OGSWebSocketManager(serverUrl: 'wss://online-go.com');
-      manager.setChannel(mockChannel);
+      // Create the manager with custom channel factory
+      final manager = OGSWebSocketManager(
+        serverUrl: 'wss://online-go.com',
+        createChannel: (_) => mockChannel,
+      );
+
+      // Connect to establish the channel
+      await manager.connect();
 
       // Arrange
       const command = 'test/command';
@@ -56,9 +61,14 @@ void main() {
       final mockChannel =
           StreamChannel(serverToClient.stream, clientToServer.sink);
 
-      // Create the manager and set the mock channel
-      final manager = OGSWebSocketManager(serverUrl: 'wss://online-go.com');
-      manager.setChannel(mockChannel);
+      // Create the manager with custom channel factory
+      final manager = OGSWebSocketManager(
+        serverUrl: 'wss://online-go.com',
+        createChannel: (_) => mockChannel,
+      );
+
+      // Connect to establish the channel
+      await manager.connect();
 
       // Arrange
       const command = 'invalid/command';

--- a/test/ogs_websocket_test.dart
+++ b/test/ogs_websocket_test.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:wqhub/game_client/ogs/ogs_websocket_manager.dart';
+
+void main() {
+  group('OGSWebSocketManager sendAndGetResponse', () {
+    test('success case - server responds with data', () async {
+      // Create StreamControllers for bidirectional communication
+      final serverToClient = StreamController<dynamic>();
+      final clientToServer = StreamController<dynamic>();
+
+      // Create a StreamChannel using the controllers
+      final mockChannel =
+          StreamChannel(serverToClient.stream, clientToServer.sink);
+
+      // Create the manager and set the mock channel
+      final manager = OGSWebSocketManager(serverUrl: 'wss://online-go.com');
+      manager.setChannel(mockChannel);
+
+      // Arrange
+      const command = 'test/command';
+      final data = {'test': 'data'};
+      final expectedResponse = {'result': 'success', 'value': 42};
+
+      // Start the request
+      final responseFuture = manager.sendAndGetResponse(command, data);
+
+      // Capture the sent message and extract request ID
+      final sentMessage = await clientToServer.stream.first;
+      final sentData = jsonDecode(sentMessage.toString());
+      final requestId = sentData[2] as int;
+
+      // Simulate server response - OGS format: [requestId, responseData, null]
+      final serverResponse = [requestId, expectedResponse, null];
+      serverToClient.add(jsonEncode(serverResponse));
+
+      // Assert
+      expect(await responseFuture, expectedResponse);
+
+      // Clean up
+      await manager.disconnect();
+      await serverToClient.close();
+      await clientToServer.close();
+      manager.dispose();
+    });
+
+    test('error case - server responds with error', () async {
+      // Create StreamControllers for bidirectional communication
+      final serverToClient = StreamController<dynamic>();
+      final clientToServer = StreamController<dynamic>();
+
+      // Create a StreamChannel using the controllers
+      final mockChannel =
+          StreamChannel(serverToClient.stream, clientToServer.sink);
+
+      // Create the manager and set the mock channel
+      final manager = OGSWebSocketManager(serverUrl: 'wss://online-go.com');
+      manager.setChannel(mockChannel);
+
+      // Arrange
+      const command = 'invalid/command';
+      final data = {'invalid': 'data'};
+      final expectedError = 'Command not found';
+
+      // Start the request
+      final responseFuture = manager.sendAndGetResponse(command, data);
+
+      // Capture the sent message and extract request ID
+      final sentMessage = await clientToServer.stream.first;
+      final sentData = jsonDecode(sentMessage.toString());
+      final requestId = sentData[2] as int;
+
+      // Simulate server error response
+      final serverResponse = [requestId, null, expectedError];
+      serverToClient.add(jsonEncode(serverResponse));
+
+      // Assert
+      await expectLater(responseFuture, throwsA(equals(expectedError)));
+
+      // Clean up
+      await manager.disconnect();
+      await serverToClient.close();
+      await clientToServer.close();
+      manager.dispose();
+    });
+  });
+}


### PR DESCRIPTION
Since the logic is a little complicated, I figure it would benefit from a unit test.  sendAndGetResponse in particular makes assumptions based on the docs that wasn't easy to test with manual E2E (specifically, the error path)

Implementation Note: in order to fake the network connection, I modify `OGSWebsocketManager` so that an arbitrary `StreamChannel` may be injected.