### PR TITLE
Join and leave game chat

### DIFF
--- a/lib/game_client/ogs/ogs_websocket_manager.dart
+++ b/lib/game_client/ogs/ogs_websocket_manager.dart
@@ -155,11 +155,17 @@ class OGSWebSocketManager {
 
   void joinGame(String gameId) {
     send('game/connect', {'game_id': int.parse(gameId)});
+    // It's a bit absurd that OGS requires joining the chat channel,
+    // but this does two things (not chat related):
+    //  - It shows the player as "online" (the green dot over the avatar)
+    //  - It makes the server wait for the player to accept the score when the game ends.
+    send('chat/join', {'channel': 'game-$gameId'});
     _log.fine('Joining game: $gameId');
   }
 
   void leaveGame(String gameId) {
     send('game/disconnect', {'game_id': int.parse(gameId)});
+    send('chat/part', {'channel': 'game-$gameId'});
     _log.fine('Leaving game: $gameId');
   }
 


### PR DESCRIPTION
As described in the comment, this isn't because we need to read the chats. Rather, this is the indicator OGS uses to determine whether the user is connected.

This becomes a little more important for scoring - if the user hasn't connected to chat, the server will not wait for their input for scoring. It will just use the opponent's selection of dead stones.

You can see the green dots over the avatars in this screenshot:

<img width="348" height="147" alt="Screenshot 2025-09-27 at 9 04 14 PM" src="https://github.com/user-attachments/assets/469eea05-70bc-4eea-9397-b1134839ba44" />
