### PR TITLE
Add condition for code formatting in CI workflow

### DIFF
--- a/.github/workflows/community_ci.yaml
+++ b/.github/workflows/community_ci.yaml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Check code formatting
         run: dart format --set-exit-if-changed .
+        if: matrix.flutter-name == 'Latest Stable'
 
       - name: Analyze code
         run: flutter analyze


### PR DESCRIPTION
Only format on Latest, since apparently 3.32 doesn't agree

Based on signals in this PR, not everything is fixed, but now it fails in compilation:

```
  error • Undefined name 'RadioGroup' • lib/settings/language_page.dart:25:13 • undefined_identifier
  error • The method 'new' isn't defined for the type '<unknown>' • lib/settings/language_page.dart:25:24 • undefined_method
  error • The named parameter 'groupValue' is required, but there's no corresponding argument • lib/settings/language_page.dart:34:15 • missing_required_argument
  error • The named parameter 'onChanged' is required, but there's no corresponding argument • lib/settings/language_page.dart:34:15 • missing_required_argument
```

We should keep that step in because it's directly related to the Windows failures which do need to compile with 3.32.