### PR TITLE
Accept stones

### DIFF
--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -333,6 +333,7 @@ class OGSGameClient extends GameClient {
           ),
           previousMoves: [],
           webSocketManager: _webSocketManager,
+          myUserId: _userInfo.value?.userId ?? '',
         );
 
         // TODO: there's chance of a race where the automatch may have been created, but

--- a/lib/game_client/ogs/territory_calculator.dart
+++ b/lib/game_client/ogs/territory_calculator.dart
@@ -9,15 +9,17 @@ import 'package:wqhub/wq/wq.dart' as wq;
 /// Returns a [CountingResult] with territory ownership, winner, and score lead.
 ///
 /// Scoring includes:
-/// - Living stones (1 point each)
 /// - Territory controlled (1 point per intersection)
 /// - Captured stones (1 point per removed stone for the opponent)
 /// - Komi compensation for white
+/// TODO: handle seki and dame points correctly (for Japanese rules)
 CountingResult calculateTerritory(
   BoardState boardState,
   List<wq.Point> removedStones,
-  double komi,
-) {
+  double komi, {
+  int blackCaptures = 0,
+  int whiteCaptures = 0,
+}) {
   final boardSize = boardState.size;
 
   // Calculate territory ownership for each point
@@ -49,7 +51,13 @@ CountingResult calculateTerritory(
   var blackScore = 0.0;
   var whiteScore = 0.0;
 
-  // Count captured stones
+  // Add capture counts from gameplay
+  blackScore +=
+      whiteCaptures.toDouble(); // Black gets points for capturing white stones
+  whiteScore +=
+      blackCaptures.toDouble(); // White gets points for capturing black stones
+
+  // Count captured stones from manual removal
   for (final removedPoint in removedStones) {
     final removedStoneColor = boardState[removedPoint];
     if (removedStoneColor == wq.Color.black) {

--- a/lib/game_client/ogs/territory_calculator.dart
+++ b/lib/game_client/ogs/territory_calculator.dart
@@ -1,0 +1,183 @@
+import 'package:wqhub/board/board_state.dart';
+import 'package:wqhub/game_client/counting_result.dart';
+import 'package:wqhub/wq/wq.dart' as wq;
+
+/// Calculate territory ownership and score after stone removal
+///
+/// Takes a [BoardState] representing the final board position and a list of
+/// [removedStones] that should be considered dead/removed, plus [komi].
+/// Returns a [CountingResult] with territory ownership, winner, and score lead.
+///
+/// Scoring includes:
+/// - Living stones (1 point each)
+/// - Territory controlled (1 point per intersection)
+/// - Captured stones (1 point per removed stone for the opponent)
+/// - Komi compensation for white
+CountingResult calculateTerritory(
+  BoardState boardState,
+  List<wq.Point> removedStones,
+  double komi,
+) {
+  final boardSize = boardState.size;
+
+  // Calculate territory ownership for each point
+  final ownership =
+      List.generate(boardSize, (i) => List<wq.Color?>.filled(boardSize, null));
+
+  // Simple territory calculation using flood fill
+  final visited =
+      List.generate(boardSize, (i) => List<bool>.filled(boardSize, false));
+
+  for (int r = 0; r < boardSize; r++) {
+    for (int c = 0; c < boardSize; c++) {
+      final point = (r, c);
+      if (!visited[r][c] &&
+          (boardState[point] == null || removedStones.contains(point))) {
+        // This is an empty point or removed stone, determine territory ownership
+        final territoryColor = _calculatePointTerritory(
+            boardState, point, visited, removedStones, boardSize);
+        if (territoryColor != null) {
+          // Fill the entire territory region with this color
+          _fillTerritoryRegion(point, territoryColor, ownership, boardState,
+              removedStones, boardSize);
+        }
+      }
+    }
+  }
+
+  // Count score
+  var blackScore = 0.0;
+  var whiteScore = 0.0;
+
+  // Count captured stones
+  for (final removedPoint in removedStones) {
+    final removedStoneColor = boardState[removedPoint];
+    if (removedStoneColor == wq.Color.black) {
+      whiteScore += 1.0; // White gets a point for capturing black
+    } else if (removedStoneColor == wq.Color.white) {
+      blackScore += 1.0; // Black gets a point for capturing white
+    }
+  }
+
+  for (int r = 0; r < boardSize; r++) {
+    for (int c = 0; c < boardSize; c++) {
+      final point = (r, c);
+      final stoneColor = boardState[point];
+      final territoryColor = ownership[r][c];
+
+      // Count territory
+      if (stoneColor == null || removedStones.contains(point)) {
+        if (territoryColor == wq.Color.black) {
+          blackScore += 1.0;
+        } else if (territoryColor == wq.Color.white) {
+          whiteScore += 1.0;
+        }
+      }
+    }
+  }
+
+  // Add komi for white
+  whiteScore += komi;
+
+  // Determine winner and score lead
+  final scoreLead = (blackScore - whiteScore).abs();
+  final winner = blackScore > whiteScore ? wq.Color.black : wq.Color.white;
+
+  return CountingResult(
+    winner: winner,
+    scoreLead: scoreLead,
+    ownership: ownership,
+  );
+}
+
+/// Determine territory ownership for an empty region using flood fill
+wq.Color? _calculatePointTerritory(
+  BoardState boardState,
+  wq.Point startPoint,
+  List<List<bool>> visited,
+  List<wq.Point> removedStones,
+  int boardSize,
+) {
+  final queue = <wq.Point>[startPoint];
+  final surroundingColors = <wq.Color>{};
+
+  while (queue.isNotEmpty) {
+    final point = queue.removeAt(0);
+    final (r, c) = point;
+
+    if (r < 0 || r >= boardSize || c < 0 || c >= boardSize || visited[r][c]) {
+      continue;
+    }
+
+    final stoneColor = boardState[point];
+
+    if (stoneColor != null && !removedStones.contains(point)) {
+      // This is a living stone, record its color
+      surroundingColors.add(stoneColor);
+      continue;
+    }
+
+    // This is an empty point or removed stone
+    visited[r][c] = true;
+
+    // Add neighbors to queue
+    final neighbors = [(r - 1, c), (r + 1, c), (r, c - 1), (r, c + 1)];
+
+    for (final neighbor in neighbors) {
+      queue.add(neighbor);
+    }
+  }
+
+  // Determine ownership based on surrounding colors
+  if (surroundingColors.length == 1) {
+    // Territory is surrounded by only one color
+    return surroundingColors.first;
+  } else {
+    // Territory is contested or neutral
+    return null;
+  }
+}
+
+/// Fill a territory region with the specified color
+void _fillTerritoryRegion(
+  wq.Point startPoint,
+  wq.Color color,
+  List<List<wq.Color?>> ownership,
+  BoardState boardState,
+  List<wq.Point> removedStones,
+  int boardSize,
+) {
+  final queue = <wq.Point>[startPoint];
+  final visited = <wq.Point>{};
+
+  while (queue.isNotEmpty) {
+    final point = queue.removeAt(0);
+    final (r, c) = point;
+
+    if (r < 0 ||
+        r >= boardSize ||
+        c < 0 ||
+        c >= boardSize ||
+        visited.contains(point)) {
+      continue;
+    }
+
+    final stoneColor = boardState[point];
+
+    if (stoneColor != null && !removedStones.contains(point)) {
+      // This is a living stone, stop
+      continue;
+    }
+
+    // This is an empty point or removed stone
+    visited.add(point);
+    ownership[r][c] = color;
+
+    // Add neighbors
+    final neighbors = [(r - 1, c), (r + 1, c), (r, c - 1), (r, c + 1)];
+
+    for (final neighbor in neighbors) {
+      queue.add(neighbor);
+    }
+  }
+}

--- a/test/territory_calculator_test.dart
+++ b/test/territory_calculator_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wqhub/board/board_state.dart';
+import 'package:wqhub/game_client/ogs/territory_calculator.dart';
+import 'package:wqhub/wq/wq.dart' as wq;
+
+void main() {
+  test('calculate territory with small board', () {
+    // 5x5 board with clear territories
+    final boardState = BoardState(size: 5);
+
+    // Black will control the top, White the bottom
+    boardState.move((col: wq.Color.black, p: (0, 1)));
+    boardState.move((col: wq.Color.white, p: (0, 2)));
+    boardState.move((col: wq.Color.black, p: (1, 1)));
+    boardState.move((col: wq.Color.white, p: (1, 2)));
+    boardState.move((col: wq.Color.black, p: (2, 1)));
+    boardState.move((col: wq.Color.white, p: (2, 2)));
+    boardState.move((col: wq.Color.black, p: (3, 1)));
+    boardState.move((col: wq.Color.white, p: (3, 2)));
+    boardState.move((col: wq.Color.black, p: (4, 1)));
+    boardState.move((col: wq.Color.white, p: (4, 2)));
+
+    // black places a stone in white's territory (we'll remove it)
+    boardState.move((col: wq.Color.black, p: (2, 4)));
+
+    final removedStones = <wq.Point>[(2, 4)];
+    final komi = 5.5;
+
+    final result = calculateTerritory(boardState, removedStones, komi);
+
+    expect(result.ownership.length, equals(5));
+
+    for (var row in result.ownership) {
+      expect(row,
+          equals([wq.Color.black, null, null, wq.Color.white, wq.Color.white]));
+    }
+
+    // Black has 5 points of territory. White has 10 points of territory and one capture
+    expect(result.winner, equals(wq.Color.white));
+    expect(result.scoreLead, equals(11.5));
+  });
+}


### PR DESCRIPTION
*Opening this PR for early feedback, but beta.online-go.com is busted at the moment, so I still need to re-test after my last commit.*

This PR adds the ability to Accept your opponents selection of the dead stones.

1) both players pass
2) Opponent (non-WQHub user) selects dead stones or uses the Auto-score button
3) Opponent accepts stones
4) WeiqiHub shows the marked territory to the user
5) User can accept to end the game or reject to keep playing

<img width="1658" height="634" alt="Screenshot 2025-09-28 at 9 27 54 PM" src="https://github.com/user-attachments/assets/1574578c-68f2-4f39-a0e0-305d7b7b316c" />


