### PR TITLE
OGS: Allow user to re-join a game

### DIFF
--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -286,11 +286,9 @@ class OGSGameClient extends GameClient {
         return null;
       }
 
-      // Get the first ongoing game
       final gameData = results.first;
       final gameId = gameData['id'].toString();
 
-      // Use the getGameFromId method to create the game instance
       return await getGameFromId(gameId);
     } catch (e) {
       _logger.warning('Failed to get ongoing game: $e');
@@ -305,7 +303,6 @@ class OGSGameClient extends GameClient {
       throw Exception('Not logged in');
     }
 
-    // Fetch game data from OGS API
     final response = await _httpClient.get(
       Uri.parse('$serverUrl/api/v1/games/$gameId'),
       headers: {
@@ -357,7 +354,6 @@ class OGSGameClient extends GameClient {
       throw Exception('Unable to determine player color for game $gameId');
     }
 
-    // Parse move history from game data
     final previousMoves = _parseMovesFromGameData(gameData);
 
     return OGSGame(

--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -324,8 +324,8 @@ class OGSGameClient extends GameClient {
     final komi = (gameData['komi'] as num?)?.toDouble() ?? 6.5;
 
     // Parse rules
-    final rulesString = gameData['rules'] as String? ?? 'japanese';
-    final rules = switch (rulesString.toLowerCase()) {
+    final rulesString = gameData['rules'] as String?;
+    final rules = switch (rulesString?.toLowerCase()) {
       'chinese' => Rules.chinese,
       'korean' => Rules.korean,
       _ => Rules.japanese,
@@ -599,7 +599,7 @@ class OGSGameClient extends GameClient {
     for (int i = 0; i < movesData.length; i++) {
       final moveData = movesData[i];
 
-      final color = i % 2 == 0 ? wq.Color.black : wq.Color.white;
+      final color = wq.Color.values[i % 2];
 
       if (moveData is List && moveData.length >= 2) {
         // OGS format: [col, row, time] where -1,-1 is pass


### PR DESCRIPTION
Part of #54

This is the implementation for `OGSGame.ongoingGame()`

Motivation:

- For users, this is how you re-join a game if you disconnected in the middle of a game
- Very helpful for testing custom configs, rather than relying on the automatch algorithm.

Notes:

- OGS allows more than one game at once.
    - It is very common for people to have many correspondence games ongoing.
    - It is uncommon for users to have more than one live game.
    - This impl selects one of the live games, if there is one.
- This PR extracts OGSGame creation into a separate method, which we share with automatch

Testing:

1) play game
2) reload the app
3) login
4) observe we are pulled into the ongoing game

https://github.com/user-attachments/assets/58ea0db1-f2ee-4540-bba7-cbe0997fd4b7

^ thanks to this feature, I was able to test on 5x5 with a bot! Much faster!

