### PR TITLE
OGS: Add clocks

### DIFF
--- a/lib/game_client/ogs/ogs_game.dart
+++ b/lib/game_client/ogs/ogs_game.dart
@@ -337,35 +337,21 @@ class OGSGame extends Game {
     _logger.fine('Received clock update for game $id');
 
     try {
-      final currentPlayer = data['current_player'] as int?;
-      final blackPlayerId = data['black_player_id'] as int?;
-      final whitePlayerId = data['white_player_id'] as int?;
       final blackTimeData = data['black_time'] as Map<String, dynamic>?;
       final whiteTimeData = data['white_time'] as Map<String, dynamic>?;
 
-      // Increment tick ID to signal time update
-      final currentBlackTime = blackTime.value;
-      final currentWhiteTime = whiteTime.value;
-
       if (blackTimeData != null) {
-        final timeState = _parseOGSTimeData(blackTimeData);
-        // Use current tick ID + 1 if this is the current player, otherwise keep same tick ID
-        final isCurrentPlayer = currentPlayer == blackPlayerId;
-        final tickId =
-            isCurrentPlayer ? currentBlackTime.$1 + 1 : currentBlackTime.$1;
-        blackTime.value = (tickId, timeState);
+        blackTime.value =
+            (blackTime.value.$1 + 1, _parseOGSTimeData(blackTimeData));
       }
 
       if (whiteTimeData != null) {
-        final timeState = _parseOGSTimeData(whiteTimeData);
-        // Use current tick ID + 1 if this is the current player, otherwise keep same tick ID
-        final isCurrentPlayer = currentPlayer == whitePlayerId;
-        final tickId =
-            isCurrentPlayer ? currentWhiteTime.$1 + 1 : currentWhiteTime.$1;
-        whiteTime.value = (tickId, timeState);
+        whiteTime.value =
+            (whiteTime.value.$1 + 1, _parseOGSTimeData(whiteTimeData));
       }
 
-      _logger.fine('Updated clock for game $id: current_player=$currentPlayer');
+      _logger.fine(
+          'Updated clock for game $id: blackTime=${blackTime.value}, whiteTime=${whiteTime.value}');
     } catch (error) {
       _logger.warning('Error handling clock update for game $id: $error');
     }

--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -75,7 +75,7 @@ class OGSGameClient extends GameClient {
         aiRefereeMinMoveCount: const IMapConst({}),
         forcedCounting: false, // OGS handles counting differently
         forcedCountingMinMoveCount: const IMapConst({}),
-        localTimeControl: false, // OGS handles time control server-side
+        localTimeControl: true,
       );
 
   @override


### PR DESCRIPTION
Part of #54 

Accept the `game/$id/clock` message, and update `blackTime` and `whiteTime` accordingly.

https://github.com/user-attachments/assets/4b3b7d1b-57d2-4159-93df-a49b9d257a1a

In the video, they don't match up perfectly.  Perhaps because OGS does some magic to account for network lag.  But I think this is an improvement over the static clocks.

