### PR TITLE
ogs: modify scoring methods to reflect manual scoring

### DIFF
--- a/lib/game_client/ogs/ogs_game.dart
+++ b/lib/game_client/ogs/ogs_game.dart
@@ -81,6 +81,32 @@ class OGSGame extends Game {
     }
   }
 
+  Future<void> toggleManuallyRemovedStones(
+      List<wq.Point> stones, bool removed) async {
+    if (_currentPhase != 'stone removal') {
+      _logger.warning(
+          'toggleManuallyRemovedStones called outside of stone removal phase');
+      return;
+    }
+
+    try {
+      final stonesString = stones.map((point) => point.toSgf()).join();
+
+      _webSocketManager.send('game/removed_stones/set', {
+        'game_id': int.parse(id),
+        'stones': stonesString,
+        'removed': removed,
+      });
+
+      _logger.fine(
+          'Sent stone removal proposal for game $id: stones=$stonesString, removed=$removed');
+    } catch (error) {
+      _logger.warning(
+          'Failed to send stone removal proposal for game $id: $error');
+      rethrow;
+    }
+  }
+
   @override
   Future<void> agreeToAutomaticCounting(bool agree) => Future.value();
 


### PR DESCRIPTION
As discussed in chat, we're going to add manual scoring ([chat link](https://discord.com/channels/1077299199684653126/1141811379158921266/1425322614590672908)).  This PR reflects the OGSGame changes, and hopefully makes it easier to test.  There are a few changes expected to the UI code:

- `countingResults` should no longer trigger a modal, but still update the territory markings on the board
- `countingResultResponses` will signal acceptance/rejection of the stones.
    - `false` -> move from `GameState.counting` to `GameState.playing`
    - `true` -> display to the user that opponent has accepted (optional)
- User will be able to click stones on the board to mark them dead (or not dead). This will call `toggleStonesManuallyRemoved()`

## Testing

I haven't done any manual testing, since this is dependent on UI changes.  But I hope this makes it easier to implement/test the UI side.