### PR TITLE
ogs: connection status indicator

### DIFF
--- a/lib/game_client/ogs/ogs_game.dart
+++ b/lib/game_client/ogs/ogs_game.dart
@@ -142,7 +142,6 @@ class OGSGame extends Game {
     final event = message['event'] as String;
     final gamePrefix = 'game/$id/';
 
-    // Handle chat presence messages for this game's channel
     if (event == 'chat-join' || event == 'chat-part') {
       _handleChatPresence(message);
       return;
@@ -185,40 +184,33 @@ class OGSGame extends Game {
     final data = message['data'] as Map<String, dynamic>;
     final channel = data['channel'] as String;
 
-    // Only handle presence for this game's chat channel
     if (channel != 'game-$id') {
       return;
     }
 
     if (event == 'chat-join') {
-      // Handle users joining the chat
       final users = data['users'] as List<dynamic>;
       for (final user in users) {
         final userId = user['id'].toString();
         _logger.fine('User $userId joined game-$id chat');
 
-        // Update player presence directly
         _updatePlayerOnlineStatus(userId, true);
       }
     } else if (event == 'chat-part') {
-      // Handle user leaving the chat
       final user = data['user'] as Map<String, dynamic>;
       final userId = user['id'].toString();
       _logger.fine('User $userId left game-$id chat');
 
-      // Update player presence directly
       _updatePlayerOnlineStatus(userId, false);
     }
   }
 
   void _updatePlayerOnlineStatus(String userId, bool isOnline) {
-    // Update black player if this is them
     if (black.value.userId == userId && black.value.online != isOnline) {
       black.value = black.value.copyWith(online: isOnline);
       _logger.fine('Updated black player presence: $isOnline');
     }
 
-    // Update white player if this is them
     if (white.value.userId == userId && white.value.online != isOnline) {
       white.value = white.value.copyWith(online: isOnline);
       _logger.fine('Updated white player presence: $isOnline');


### PR DESCRIPTION
`UserInfo` has a field for connection status.  OGS also has an indicator for connection status.  This indicator is powered by the chat channel messages `chat-join` and `chat-part`.  See [ChatPresenseIndicator.tsx](https://github.com/online-go/online-go.com/blob/devel/src/components/ChatPresenceIndicator/ChatPresenceIndicator.tsx).

## Manual testing

Observe that the green WiFi symbol goes from green to red as I navigate the opponent away from the game page.

https://github.com/user-attachments/assets/9990f615-b2ce-47ad-8bef-276d5de535af

## Potential for improvement

The indicator for the user's card is not very useful as we are connected to the chat the entire time the game is open.  A more useful indicator would be websocket connection status.

I've opted not to go this route for now:

- This is the simpler way
- It's what OGS does
- If WS disconnects, we probably have bigger problems elsewhere