### PR TITLE
[ogs] Add winner to game result

### DIFF
--- a/lib/game_client/ogs/game_utils.dart
+++ b/lib/game_client/ogs/game_utils.dart
@@ -1,5 +1,15 @@
 import 'package:wqhub/wq/wq.dart' as wq;
 
+/// Returns formatted result string with winner prefix (e.g., "B + Resignation", "W + 5.5 points").
+String formatGameResult(wq.Color? winner, String outcome) {
+  String winnerPrefix = switch (winner) {
+    wq.Color.black => 'B + ',
+    wq.Color.white => 'W + ',
+    null => '',
+  };
+  return '$winnerPrefix$outcome';
+}
+
 /// Parse a string of SGF coordinates into a list of points.
 ///
 /// Parameters:

--- a/lib/game_client/ogs/ogs_game.dart
+++ b/lib/game_client/ogs/ogs_game.dart
@@ -404,18 +404,9 @@ class OGSGame extends Game {
       }
     }
 
-    // Map OGS outcome to our result format
-    final result = switch (outcome.toLowerCase()) {
-      'resignation' => 'Resignation',
-      'timeout' => 'Time',
-      'cancellation' => 'Cancellation',
-      // Score-based results, e.g. "W+5.5"
-      _ => outcome, // Keep original for score-based results
-    };
-
     return GameResult(
       winner: winner,
-      result: result,
+      result: formatGameResult(winner, outcome),
       description: outcome,
     );
   }

--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -478,7 +478,7 @@ class OGSGameClient extends GameClient {
 
         final result = GameResult(
           winner: winner,
-          result: outcome,
+          result: formatGameResult(winner, outcome),
         );
 
         return GameSummary(


### PR DESCRIPTION
I must have assumed GamePage was going to combine winner and outcome somehow.  But that doesn't seem to be the case, so the result ended up being hard to parse.

The updated text looks like:

<img width="297" height="191" alt="Screenshot 2025-11-02 at 6 47 03 PM" src="https://github.com/user-attachments/assets/d6728a71-0736-4c1c-b5a9-87f13a6f52be" />
<img width="116" height="388" alt="Screenshot 2025-11-02 at 6 47 35 PM" src="https://github.com/user-attachments/assets/c8e7380c-a009-4559-9eb7-cdbbcc8ed5f2" />
