### PR TITLE
[ogs] disable autoscore

### DIFF
--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -69,7 +69,7 @@ class OGSGameClient extends GameClient {
   @override
   ServerFeatures get serverFeatures => ServerFeatures(
         manualCounting: true,
-        automaticCounting: true,
+        automaticCounting: false,
         aiReferee: false, // OGS's AI referee cannot be called on-demand
         aiRefereeMinMoveCount: const IMapConst({}),
         forcedCounting: false, // OGS handles counting differently


### PR DESCRIPTION
The autoscore of OGS is fundamentally different than that of Fox. I think it's better to disable it completely than to try and fit OGS's autoscore into the shared interface.

Note that we still request an automatic count at the beginning of the scoring phase.