### PR TITLE
Alternate first color to play (#134)

### DIFF
--- a/lib/main_page.dart
+++ b/lib/main_page.dart
@@ -28,6 +28,7 @@ import 'package:wqhub/train/time_frenzy_page.dart';
 import 'package:wqhub/train/tags_page.dart';
 import 'package:wqhub/train/train_stats_page.dart';
 import 'package:wqhub/window_class_aware_state.dart';
+import 'package:wqhub/wq/wq.dart' as wq;
 
 enum MainPageDestination { home, play, train }
 
@@ -358,7 +359,7 @@ class _Train extends StatelessWidget {
         if (task != null) {
           if (context.mounted) {
             if (context.settings.alwaysBlackToPlay) {
-              task = task.withBlackToPlay();
+              task = task.withColorToPlay(wq.Color.black);
             }
             task = task.withRandomSymmetry(
                 randomize: context.settings.randomizeTaskOrientation);

--- a/lib/train/task_repository.dart
+++ b/lib/train/task_repository.dart
@@ -80,21 +80,21 @@ class Task {
       required this.initialStones,
       required this.variationTree});
 
-  Task withBlackToPlay() => switch (first) {
-        wq.Color.black => this,
-        wq.Color.white => Task(
-            id: id,
-            rank: rank,
-            type: type,
-            first: wq.Color.black,
-            boardSize: boardSize,
-            subBoardSize: subBoardSize,
-            topLeft: topLeft,
-            initialStones: IMapOfSets({
-              wq.Color.black: initialStones.get(wq.Color.white),
-              wq.Color.white: initialStones.get(wq.Color.black),
-            }),
-            variationTree: variationTree,
+  Task withColorToPlay(wq.Color color) => switch (first == color) {
+      true => this,
+      false => Task(
+          id: id,
+          rank: rank,
+          type: type,
+          first: color,
+          boardSize: boardSize,
+          subBoardSize: subBoardSize,
+          topLeft: topLeft,
+          initialStones: IMapOfSets({
+            wq.Color.black: initialStones.get(wq.Color.white),
+            wq.Color.white: initialStones.get(wq.Color.black),
+          }),
+          variationTree: variationTree,
           ),
       };
 

--- a/lib/train/task_source/black_to_play_source.dart
+++ b/lib/train/task_source/black_to_play_source.dart
@@ -1,17 +1,18 @@
 import 'package:wqhub/train/task_repository.dart';
 import 'package:wqhub/train/task_source/task_source.dart';
 import 'package:wqhub/train/variation_tree.dart';
+import 'package:wqhub/wq/wq.dart' as wq;
 
 final class BlackToPlaySource extends TaskSource {
   final TaskSource source;
   final bool blackToPlay;
+  bool nextShouldBeBlackToPlay = true;
 
   @override
   late Task task;
 
   BlackToPlaySource({required this.source, required this.blackToPlay}) {
-    task = source.task;
-    if (blackToPlay) task = task.withBlackToPlay();
+    ensureFirstColor(source.task);
   }
 
   @override
@@ -23,8 +24,18 @@ final class BlackToPlaySource extends TaskSource {
     if (!source.next(prevStatus, prevSolveTime, onRankChanged: onRankChanged)) {
       return false;
     }
-    task = source.task;
-    if (blackToPlay) task = task.withBlackToPlay();
+    ensureFirstColor(source.task);
     return true;
+  }
+
+  void ensureFirstColor(Task sourceTask) {
+    if (blackToPlay) {
+      task = sourceTask.withColorToPlay(wq.Color.black);
+    } else {
+      task = sourceTask.withColorToPlay(
+          nextShouldBeBlackToPlay ? wq.Color.black : wq.Color.white);
+      nextShouldBeBlackToPlay =
+          !nextShouldBeBlackToPlay; //alternate first color to move
+    }
   }
 }


### PR DESCRIPTION
First task is always black-to-play. 
Subsequent tasks alternate the starting color based on the **Always black to play" option.