### PR TITLE
sgf: fix issues with pandanet files

### DIFF
--- a/lib/parse/sgf/sgf.dart
+++ b/lib/parse/sgf/sgf.dart
@@ -28,15 +28,13 @@ class _SgfDefinition extends GrammarDefinition {
   Parser<List<SgfTree>> collection() =>
       ref0(gameTree).plusSeparated(ref0(space)).map((l) => l.elements);
 
-  Parser<SgfTree> gameTree() => (ref0(nodeSeq) &
-          ref0(gameTree).starSeparated(ref0(space)) &
-          (char(')').not() & any())
-              .star()) // Allow junk after variations (e.g., IGS/Pandanet's OS[])
-      .skip(before: char('(').trim(), after: char(')').trim())
-      .map((l) => SgfTree(
-            nodes: l[0],
-            children: l[1].elements,
-          ));
+  Parser<SgfTree> gameTree() =>
+      (ref0(nodeSeq) & ref0(gameTree).starSeparated(ref0(space)))
+          .skip(before: char('(').trim(), after: char(')').trim())
+          .map((l) => SgfTree(
+                nodes: l[0],
+                children: l[1].elements,
+              ));
 
   Parser<List<SgfNode>> nodeSeq() =>
       ref0(node).plusSeparated(ref0(space)).map((r) => r.elements);

--- a/test/sgf_test.dart
+++ b/test/sgf_test.dart
@@ -181,19 +181,17 @@ void main() {
     expect(tree.nodes[2]['W'], ['ce']);
   });
 
-  test('should allow trailing junk before closing paren', () {
-    // Test that arbitrary content after variations is ignored
-    // This is non-standard, but Pandanet SGF files place this OS[] property
-    // after the last move.
-    const sgfData = '(;GM[1]FF[4]SZ[9];B[aa];W[bb]junk\nmore junk\nOS[])';
+  test('should allow trailing fields', () {
+    const sgfData = '(;GM[1]FF[4]SZ[9];B[aa];W[bb];\n\nOS[]\n\n)';
     final sgf = Sgf.parse(sgfData);
     expect(sgf.trees.length, 1);
 
     final tree = sgf.trees.first;
-    expect(tree.nodes.length, 3);
+    expect(tree.nodes.length, 4);
     expect(tree.nodes[0]['GM'], ['1']);
     expect(tree.nodes[1]['B'], ['aa']);
     expect(tree.nodes[2]['W'], ['bb']);
+    expect(tree.nodes[3]['OS'], ['']);
 
     final rec = GameRecord.fromSgf(sgfData);
     expect(rec.moves.length, 2);


### PR DESCRIPTION
From discussion on #112 

- `CoPyright` instead of `CP`
    - Fix: allow lowercase in props, but remove them from the output
    - I used [Sabaki](https://github.com/SabakiHQ/sgf) (MIT License) tests and source as inspiration as it seems to do a good job handling this.
- Whitespace after the initial `(;`
    - Fix: allow it. Generally, whitespace between tokens shouldn't affect an SGF
- ~`OS[]` field after the game tree~
    - ~Fix: allow arbitrary characters after the game tree, and ignore them~