### PR TITLE
Fix OGSGameClient.ongoingGame picking up correspondence

### DIFF
--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -246,6 +246,7 @@ class OGSGameClient extends GameClient {
           'source': 'play',
           'ended__isnull': 'true',
           'time_per_move__lt': '3600',
+          // Exclude correspondence games with no time control
           'time_per_move__gt': '0',
         },
       );


### PR DESCRIPTION
Specifically, it was picking up games with no timer.  These are marked as `time_per_move=0`, so they were picked up as live.

Manual tests:

- checked that [a no time limit game](https://beta.online-go.com/game/19872) didn't load on login
- checked that a normal blitz game still loads on login