### PR TITLE
Add All option to custom exam for task topic

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4,6 +4,7 @@
   "accuracy": "Genauigkeit",
   "aiReferee": "KI-Schiedsrichter",
   "aiSensei": "AI Sensei",
+  "all": "Alle",
   "alwaysBlackToPlay": "Immer Schwarz am Zug",
   "alwaysBlackToPlayDesc": "Alle Aufgaben mit Schwarz am Zug aufbauen, um Verwechslung zu vermeiden",
   "appearance": "Aussehen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,6 +4,7 @@
   "accuracy": "Accuracy",
   "aiReferee": "AI referee",
   "aiSensei": "AI Sensei",
+  "all": "All",
   "alwaysBlackToPlay": "Always black-to-play",
   "alwaysBlackToPlayDesc": "Set all tasks as black-to-play to avoid confusion",
   "appearance": "Appearance",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4,6 +4,7 @@
   "accuracy": "Precisión",
   "aiReferee": "Árbitro IA",
   "aiSensei": "AI Sensei",
+  "all": "Todos",
   "alwaysBlackToPlay": "Siempre juegan las negras",
   "alwaysBlackToPlayDesc": "Hace que en todos los problemas jueguen las negras para evitar confusión",
   "appearance": "Apariencia",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4,6 +4,7 @@
   "accuracy": "Precisione",
   "aiReferee": "Arbitro AI",
   "aiSensei": "AI Sensei",
+  "all": "Tutti",
   "alwaysBlackToPlay": "Black to play!",
   "alwaysBlackToPlayDesc": "Impone la prima mossa al Nero per evitare confusione nei problemi",
   "appearance": "Aspetto",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4,6 +4,7 @@
   "accuracy": "Precizie",
   "aiReferee": "Arbitru AI",
   "aiSensei": "AI Sensei",
+  "all": "Toate",
   "alwaysBlackToPlay": "Întotdeauna negru la mutare",
   "alwaysBlackToPlayDesc": "Setează toate sarcinile ca fiind negru la mutare pentru a evita confuzia",
   "appearance": "Aspect",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -4,6 +4,7 @@
   "accuracy": "Точность",
   "aiReferee": "ИИ-судья",
   "aiSensei": "AI Sensei",
+  "all": "Все",
   "alwaysBlackToPlay": "Всегда ход чёрных",
   "alwaysBlackToPlayDesc": "Устанавливать все задачи как ход чёрных, чтобы избежать путаницы",
   "appearance": "Интерфейс",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -4,6 +4,7 @@
   "accuracy": "Точність",
   "aiReferee": "Суддя-ШІ",
   "aiSensei": "AI Sensei",
+  "all": "Всі",
   "alwaysBlackToPlay": "Завжди хід чорних",
   "alwaysBlackToPlayDesc": "Встановити перший хід чорних для усіх вправ, щоб уникнути плутанини",
   "appearance": "Оформлення",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -4,6 +4,7 @@
   "accuracy": "答题准确率",
   "aiReferee": "AI 裁判",
   "aiSensei": "AI Sensei",
+  "all": "全部",
   "alwaysBlackToPlay": "总是执黑先行",
   "alwaysBlackToPlayDesc": "永远执黑先行，防止混淆",
   "appearance": "外观",

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -122,6 +122,7 @@ Route<dynamic>? onGenerateRoute(RouteSettings settings) {
             maxMistakes: args.maxMistakes,
             taskSourceType: args.taskSourceType,
             taskTypes: args.taskTypes,
+            taskTopic: args.taskTopic,
             taskTag: args.taskTag,
             collectStats: args.collectStats,
           ));

--- a/lib/train/custom_exam_page.dart
+++ b/lib/train/custom_exam_page.dart
@@ -21,6 +21,7 @@ class CustomExamRouteArguments {
   final int maxMistakes;
   final TaskSourceType taskSourceType;
   final ISet<TaskType>? taskTypes;
+  final TaskTag? taskTopic;
   final TaskTag? taskTag;
   final bool collectStats;
 
@@ -31,6 +32,7 @@ class CustomExamRouteArguments {
       required this.maxMistakes,
       required this.taskSourceType,
       required this.taskTypes,
+      this.taskTopic,
       required this.taskTag,
       required this.collectStats});
 }
@@ -44,6 +46,7 @@ class CustomExamPage extends StatelessWidget {
   final int maxMistakes;
   final TaskSourceType taskSourceType;
   final ISet<TaskType>? taskTypes;
+  final TaskTag? taskTopic;
   final TaskTag? taskTag;
   final bool collectStats;
 
@@ -55,6 +58,7 @@ class CustomExamPage extends StatelessWidget {
       required this.maxMistakes,
       required this.taskSourceType,
       this.taskTypes,
+      this.taskTopic,
       this.taskTag,
       required this.collectStats});
 
@@ -80,6 +84,7 @@ class CustomExamPage extends StatelessWidget {
         maxMistakes: maxMistakes,
         taskSourceType: taskSourceType,
         taskTypes: taskTypes,
+        taskTopic: taskTopic,
         taskTag: taskTag,
         collectStats: collectStats,
       ),
@@ -91,8 +96,9 @@ class CustomExamPage extends StatelessWidget {
     final taskSource = switch (taskSourceType) {
       TaskSourceType.fromTaskTypes =>
         TaskRepository().taskSourceByTypes(rankRange, taskTypes!),
-      TaskSourceType.fromTaskTag =>
-        TaskRepository().taskSourceByTag(rankRange, taskTag!),
+      TaskSourceType.fromTaskTag => taskTag == null
+          ? TaskRepository().taskSourceByTopic(rankRange, taskTopic!)
+          : TaskRepository().taskSourceByTag(rankRange, taskTag!),
       TaskSourceType.fromMistakes => ConstTaskRefSource(
           taskRefs: StatsDB().mistakesByRankRange(rankRange, taskCount)),
     };


### PR DESCRIPTION
Added the All topic to custom exam when choosing a topic.

Now when you set up a custom exam:
  1. Select "From task topic" as your Task Source
  2. Choose a topic (e.g., "Beginner", "Life and Death", etc.)
  3. In the Subtopic dropdown, you'll see "All" as the first option, followed by all available subtopics
  4. Selecting "All" will source tasks from all subtopics within that topic
  5. The task distribution properly weights tasks based on availability across all subtopics and rank ranges

I know nothing about Dart, so please test this before merging. :P

note: localization - except for romanian and spanish - was done using AI.

for issue #163 