### PR TITLE
Better login errors

### DIFF
--- a/lib/game_client/exceptions.dart
+++ b/lib/game_client/exceptions.dart
@@ -1,27 +1,20 @@
-/// The type of login failure that occurred
 enum LoginFailureType {
   /// Incorrect username or password
   invalidCredentials,
 
   /// Network connectivity issues
   network,
-
-  /// Unknown or unspecified error
-  unknown,
 }
 
-/// Exception thrown when login fails
 class LoginException implements Exception {
-  final String message;
   final LoginFailureType type;
   final Object? cause;
 
-  const LoginException(
-    this.message, {
+  const LoginException({
     required this.type,
     this.cause,
   });
 
   @override
-  String toString() => 'LoginException($type): $message';
+  String toString() => 'LoginException($type)';
 }

--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' show ClientException;
 import 'package:wqhub/game_client/automatch_preset.dart';
 import 'package:wqhub/game_client/exceptions.dart';
 import 'package:wqhub/game_client/game.dart';
@@ -220,27 +222,19 @@ class OGSGameClient extends GameClient {
       if (e.statusCode == 401 || e.statusCode == 403) {
         // Authentication failed - wrong username or password
         throw const LoginException(
-          'Incorrect username or password',
           type: LoginFailureType.invalidCredentials,
         );
-      } else {
-        // Other server errors
+      }
+      rethrow;
+    } catch (e) {
+      // Check for network-related exceptions
+      if (e is SocketException || e is ClientException) {
         throw LoginException(
-          'Login failed: ${e.message}',
-          type: LoginFailureType.unknown,
+          type: LoginFailureType.network,
           cause: e,
         );
       }
-    } catch (e) {
-      // Network errors or other issues
-      if (e is LoginException) {
-        rethrow;
-      }
-      throw LoginException(
-        'Network error during login',
-        type: LoginFailureType.network,
-        cause: e,
-      );
+      rethrow;
     }
   }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -42,7 +42,7 @@
   "errFailedToLoadGameList": "Spielliste konnte nicht geladen werden. Bitte versuche es erneut.",
   "errFailedToUploadGameToAISensei": "Spiel konnte nicht zu AI Sensei hochgeladen werden",
   "errIncorrectUsernameOrPassword": "Falscher Benutzername oder falsches Passwort",
-  "errLoginFailed": "Anmeldung fehlgeschlagen. Bitte versuche es später erneut.",
+  "errLoginFailedWithDetails": "Anmeldung fehlgeschlagen: {message}",
   "errNetworkError": "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut.",
   "errMustBeAtLeast": "Muss mindestens {n} sein",
   "@errMustBeAtLeast": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -42,7 +42,14 @@
   "errFailedToLoadGameList": "Failed to load game list. Please try again.",
   "errFailedToUploadGameToAISensei": "Failed to upload game to AI Sensei",
   "errIncorrectUsernameOrPassword": "Incorrect username or password",
-  "errLoginFailed": "Login failed. Please try again later.",
+  "errLoginFailedWithDetails": "Login failed: {message}",
+  "@errLoginFailedWithDetails": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
   "errNetworkError": "Network error. Please check your connection and try again.",
   "errMustBeAtLeast": "Must be at least {n}",
   "@errMustBeAtLeast": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -42,7 +42,7 @@
   "errFailedToLoadGameList": "Error cargando lista de partidas. Por favor, prueba de nuevo.",
   "errFailedToUploadGameToAISensei": "Error enviando partida a AI Sensei",
   "errIncorrectUsernameOrPassword": "Nombre de usuario o contraseña incorrectos",
-  "errLoginFailed": "Error al iniciar sesión. Por favor, inténtalo de nuevo más tarde.",
+  "errLoginFailedWithDetails": "Error al iniciar sesión: {message}",
   "errNetworkError": "Error de red. Por favor, verifica tu conexión e inténtalo de nuevo.",
   "errMustBeAtLeast": "No puede ser menor que {n}",
   "@errMustBeAtLeast": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -42,7 +42,7 @@
   "errFailedToLoadGameList": "Impossibile caricare l'elenco delle partite. Per favore riprova più tardi.",
   "errFailedToUploadGameToAISensei": "Impossibile caricare la partita su AI Sensei",
   "errIncorrectUsernameOrPassword": "Username o password non corretti",
-  "errLoginFailed": "Accesso non riuscito. Riprova più tardi.",
+  "errLoginFailedWithDetails": "Accesso non riuscito: {message}",
   "errNetworkError": "Errore di rete. Controlla la tua connessione e riprova.",
   "errMustBeAtLeast": "Deve essere almeno {n}",
   "@errMustBeAtLeast": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -368,11 +368,11 @@ abstract class AppLocalizations {
   /// **'Incorrect username or password'**
   String get errIncorrectUsernameOrPassword;
 
-  /// No description provided for @errLoginFailed.
+  /// No description provided for @errLoginFailedWithDetails.
   ///
   /// In en, this message translates to:
-  /// **'Login failed. Please try again later.'**
-  String get errLoginFailed;
+  /// **'Login failed: {message}'**
+  String errLoginFailedWithDetails(String message);
 
   /// No description provided for @errNetworkError.
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -145,8 +145,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Falscher Benutzername oder falsches Passwort';
 
   @override
-  String get errLoginFailed =>
-      'Anmeldung fehlgeschlagen. Bitte versuche es später erneut.';
+  String errLoginFailedWithDetails(String message) {
+    return 'Anmeldung fehlgeschlagen: $message';
+  }
 
   @override
   String get errNetworkError =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -143,7 +143,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get errIncorrectUsernameOrPassword => 'Incorrect username or password';
 
   @override
-  String get errLoginFailed => 'Login failed. Please try again later.';
+  String errLoginFailedWithDetails(String message) {
+    return 'Login failed: $message';
+  }
 
   @override
   String get errNetworkError =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -144,8 +144,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Nombre de usuario o contraseña incorrectos';
 
   @override
-  String get errLoginFailed =>
-      'Error al iniciar sesión. Por favor, inténtalo de nuevo más tarde.';
+  String errLoginFailedWithDetails(String message) {
+    return 'Error al iniciar sesión: $message';
+  }
 
   @override
   String get errNetworkError =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -144,7 +144,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Username o password non corretti';
 
   @override
-  String get errLoginFailed => 'Accesso non riuscito. Riprova più tardi.';
+  String errLoginFailedWithDetails(String message) {
+    return 'Accesso non riuscito: $message';
+  }
 
   @override
   String get errNetworkError =>

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -144,8 +144,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nume de utilizator sau parolă incorecte';
 
   @override
-  String get errLoginFailed =>
-      'Autentificarea a eșuat. Te rog să încerci din nou mai târziu.';
+  String errLoginFailedWithDetails(String message) {
+    return 'Autentificarea a eșuat: $message';
+  }
 
   @override
   String get errNetworkError =>

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -144,8 +144,9 @@ class AppLocalizationsRu extends AppLocalizations {
       'Неверное имя пользователя или пароль';
 
   @override
-  String get errLoginFailed =>
-      'Вход не выполнен. Пожалуйста, попробуйте позже.';
+  String errLoginFailedWithDetails(String message) {
+    return 'Вход не выполнен: $message';
+  }
 
   @override
   String get errNetworkError =>

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -143,6 +143,15 @@ class AppLocalizationsUk extends AppLocalizations {
   String get errIncorrectUsernameOrPassword => 'Невірний логін або пароль';
 
   @override
+  String errLoginFailedWithDetails(String message) {
+    return 'Вхід не виконано: $message';
+  }
+
+  @override
+  String get errNetworkError =>
+      'Помилка мережі. Перевірте з\'єднання і спробуйте знову.';
+
+  @override
   String errMustBeAtLeast(num n) {
     return 'Повинно бути не менше $n';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -138,7 +138,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get errIncorrectUsernameOrPassword => '用户名或密码错误';
 
   @override
-  String get errLoginFailed => '登录失败，请稍后重试。';
+  String errLoginFailedWithDetails(String message) {
+    return '登录失败：$message';
+  }
 
   @override
   String get errNetworkError => '网络错误，请检查您的连接并重试。';

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -42,7 +42,7 @@
   "errFailedToLoadGameList": "Încărcarea listei de jocuri a eșuat. Te rugăm să încerci din nou.",
   "errFailedToUploadGameToAISensei": "Încărcarea jocului în AI Sensei a eșuat",
   "errIncorrectUsernameOrPassword": "Nume de utilizator sau parolă incorecte",
-  "errLoginFailed": "Autentificarea a eșuat. Te rog să încerci din nou mai târziu.",
+  "errLoginFailedWithDetails": "Autentificarea a eșuat: {message}",
   "errNetworkError": "Eroare de rețea. Te rog să verifici conexiunea și să încerci din nou.",
   "errMustBeAtLeast": "Trebuie să fie cel puțin {n}",
   "@errMustBeAtLeast": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -42,7 +42,7 @@
   "errFailedToLoadGameList": "Не удалось загрузить список партий. Пожалуйста, попробуйте снова.",
   "errFailedToUploadGameToAISensei": "Не удалось загрузить партию в AI Sensei",
   "errIncorrectUsernameOrPassword": "Неверное имя пользователя или пароль",
-  "errLoginFailed": "Вход не выполнен. Пожалуйста, попробуйте позже.",
+  "errLoginFailedWithDetails": "Вход не выполнен: {message}",
   "errNetworkError": "Ошибка сети. Проверьте подключение и попробуйте снова.",
   "errMustBeAtLeast": "Должно быть не менее {n}",
   "@errMustBeAtLeast": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -42,6 +42,8 @@
   "errFailedToLoadGameList": "Не вдалося завантажити список ігор. Спробуйте пізніше",
   "errFailedToUploadGameToAISensei": "Не вдалося завантажити гру на AI Sensei",
   "errIncorrectUsernameOrPassword": "Невірний логін або пароль",
+  "errLoginFailedWithDetails": "Вхід не виконано: {message}",
+  "errNetworkError": "Помилка мережі. Перевірте з'єднання і спробуйте знову.",
   "errMustBeAtLeast": "Повинно бути не менше {n}",
   "@errMustBeAtLeast": {
     "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -42,7 +42,7 @@
   "errFailedToLoadGameList": "加载棋局列表失败，请重试。",
   "errFailedToUploadGameToAISensei": "上传棋局到 AI Sensei 失败",
   "errIncorrectUsernameOrPassword": "用户名或密码错误",
-  "errLoginFailed": "登录失败，请稍后重试。",
+  "errLoginFailedWithDetails": "登录失败：{message}",
   "errNetworkError": "网络错误，请检查您的连接并重试。",
   "errMustBeAtLeast": "必须至少{n}",
   "@errMustBeAtLeast": {

--- a/lib/play/server_login_page.dart
+++ b/lib/play/server_login_page.dart
@@ -94,10 +94,10 @@ class _ServerLoginPageState extends State<ServerLoginPage> {
             LoginFailureType.invalidCredentials =>
               loc.errIncorrectUsernameOrPassword,
             LoginFailureType.network => loc.errNetworkError,
-            LoginFailureType.unknown => loc.errLoginFailed,
           };
         } else {
-          errorMessage = loc.errLoginFailed;
+          // For unexpected exceptions, show the error message
+          errorMessage = loc.errLoginFailedWithDetails(err.toString());
         }
 
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
Fixes #169

## Summary

Allows different error messages to be displayed when login fails.

- `LoginException` holds a typed enum that corresponds to user-friendly, localized strings
- Attempts to display information for other Exceptions as well (non-localized)
- Update OGS client to send `LoginException` where applicable

## Backwards compatibility

You'll want to teach Fox and Tygem clients about `LoginException` to get user-friendly messages, but it should be fine to merge PR this in without updating them.  It will simply display `"Login Failed: {err.toString()}"` (exception text won't be localized)

## Testing

1) login with wrong password
    - outputs existing message ("Incorrect username or password")
2) turn off wifi and log in
    - "Network error. Please check your connection and try again."
<img width="784" height="443" alt="Screenshot 2025-12-31 at 11 32 10 AM" src="https://github.com/user-attachments/assets/7a7757fe-265a-4a86-b8ed-b2408c9ff48d" />

3) Add a `throw` with a random Exception. See that error info is displayed:
    - `throw Exception('simulated error')`
    - "Login Failed: Exception: simulated error"



