### PR TITLE
Autofill for login page

### DIFF
--- a/lib/play/login_form.dart
+++ b/lib/play/login_form.dart
@@ -45,72 +45,78 @@ class _LoginFormState extends State<LoginForm> {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    return Form(
-      key: _formKey,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        spacing: 8.0,
-        children: <Widget>[
-          TextFormField(
-            controller: _usernameController,
-            enabled: widget.enabled,
-            maxLength: 32,
-            decoration: InputDecoration(
-              border: OutlineInputBorder(),
-              labelText: loc.username,
+    return AutofillGroup(
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          spacing: 8.0,
+          children: <Widget>[
+            TextFormField(
+              controller: _usernameController,
+              enabled: widget.enabled,
+              maxLength: 32,
+              autofillHints: const [AutofillHints.username],
+              textInputAction: TextInputAction.next,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: loc.username,
+              ),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Username can not be empty';
+                }
+                return null;
+              },
             ),
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return 'Username can not be empty';
-              }
-              return null;
-            },
-          ),
-          TextFormField(
-            controller: _passwordController,
-            enabled: widget.enabled,
-            maxLength: 32,
-            decoration: InputDecoration(
-              border: OutlineInputBorder(),
-              labelText: loc.password,
+            TextFormField(
+              controller: _passwordController,
+              enabled: widget.enabled,
+              maxLength: 32,
+              autofillHints: const [AutofillHints.password],
+              textInputAction: TextInputAction.done,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: loc.password,
+              ),
+              obscureText: true,
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Password can not be empty';
+                }
+                return null;
+              },
             ),
-            obscureText: true,
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return 'Password can not be empty';
-              }
-              return null;
-            },
-          ),
-          widget.enabled
-              ? Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  spacing: 8,
-                  children: [
-                    Expanded(
-                      child: ElevatedButton(
-                        onPressed: () {
-                          if (_formKey.currentState!.validate()) {
-                            widget.onSubmit(_usernameController.text,
-                                _passwordController.text);
-                          }
-                        },
-                        child: Text(loc.login),
-                      ),
-                    ),
-                    if (!Platform.isIOS &&
-                        !Platform.isMacOS &&
-                        widget.registerUrl != null)
+            widget.enabled
+                ? Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    spacing: 8,
+                    children: [
                       Expanded(
                         child: ElevatedButton(
-                          onPressed: () => _launchUrl(widget.registerUrl!),
-                          child: Text(loc.register),
+                          onPressed: () {
+                            if (_formKey.currentState!.validate()) {
+                              widget.onSubmit(_usernameController.text,
+                                  _passwordController.text);
+                            }
+                          },
+                          child: Text(loc.login),
                         ),
                       ),
-                  ],
-                )
-              : CircularProgressIndicator(),
-        ],
+                      if (!Platform.isIOS &&
+                          !Platform.isMacOS &&
+                          widget.registerUrl != null)
+                        Expanded(
+                          child: ElevatedButton(
+                            onPressed: () => _launchUrl(widget.registerUrl!),
+                            child: Text(loc.register),
+                          ),
+                        ),
+                    ],
+                  )
+                : CircularProgressIndicator(),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Changes Made

- **Wrapped login form in `AutofillGroup`**
    - groups the username and password fields
    - `AutofillGroup` disposal triggers the system's "Save password?" prompt
- **Added `autofillHints` to text fields**
- **Added `textInputAction` to text fields**: improves navigation and changes the label on the "Enter" key of the virtual keyboard

## Testing

I tested on my device (Android), but this implementation should work for other platforms.

<img src="https://github.com/user-attachments/assets/d0cea6ea-69a2-4397-915f-64f4ac5b4b93" width="200" />
<img src="https://github.com/user-attachments/assets/aa2e1721-256a-47b1-81b2-bc67563d5e46" width="200" />
<img src="https://github.com/user-attachments/assets/20b62731-ce0f-4199-a499-cc0cf417c1f3" width="200" />

On Mac, I wasn't able to get autofill working, but the page still works as before.