### PR TITLE
Exclude integration tests in CI

### DIFF
--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -41,7 +41,7 @@ jobs:
           rm lib/game_client/game_client_list.dart
           mv lib/game_client/game_client_list.dart.PROD lib/game_client/game_client_list.dart
       - name: Run tests
-        run: flutter test
+        run: flutter test --exclude-tags=integration
       - name: Build
         env:
           NO_OPUS_OGG_LIBS: 1

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -28,7 +28,7 @@ jobs:
           rm lib/game_client/game_client_list.dart
           mv lib/game_client/game_client_list.dart.PROD lib/game_client/game_client_list.dart
       - name: Run tests
-        run: flutter test
+        run: flutter test --exclude-tags=integration
       - name: Build
         env:
           NO_OPUS_OGG_LIBS: 1

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -44,7 +44,7 @@ jobs:
           rm lib/game_client/game_client_list.dart
           mv lib/game_client/game_client_list.dart.PROD lib/game_client/game_client_list.dart
       - name: Run tests
-        run: flutter test
+        run: flutter test --exclude-tags=integration
       - name: Build
         env:
           NO_OPUS_OGG_LIBS: 1


### PR DESCRIPTION
#184 broke the non-community builds (oops!)

It's because they attempt to run all tests, including integration tests and fail without ogs user credentials.  To fix, exclude integration tests.

note: this PR is totally untested because I can't run those workflows myself, but I'm pretty confident this is the fix.