### PR TITLE
add timeout problems to completed_task

### DIFF
--- a/lib/train/exam_page.dart
+++ b/lib/train/exam_page.dart
@@ -313,6 +313,7 @@ class _ExamPageState extends State<ExamPage> with TaskSolvingStateMixin {
       _mistakeCount++;
       _totalTime += widget.timePerTask;
       solveStatus = VariationStatus.wrong;
+      _completedTasks.add((currentTask.ref, false));
       if (!solveStatusNotified) {
         notifySolveTimeout(wideLayout);
         solveStatusNotified = true;


### PR DESCRIPTION
fix #200

just add to completed task the failed problem, no need to check status comparison because a timeout problem is always failed.

<img width="1387" height="427" alt="image" src="https://github.com/user-attachments/assets/78a813c9-9467-4837-a64d-56a268b20fe8" />
