### PR TITLE
add timeout problems to DB and stats

### DIFF
--- a/lib/train/exam_page.dart
+++ b/lib/train/exam_page.dart
@@ -314,6 +314,8 @@ class _ExamPageState extends State<ExamPage> with TaskSolvingStateMixin {
       _totalTime += widget.timePerTask;
       solveStatus = VariationStatus.wrong;
       _completedTasks.add((currentTask.ref, false));
+      StatsDB().addTaskAttempt(currentTask.ref, false);
+      context.stats.incrementTotalFailCount(currentTask.ref.rank);
       if (!solveStatusNotified) {
         notifySolveTimeout(wideLayout);
         solveStatusNotified = true;


### PR DESCRIPTION
fix #205

5D problem stats previously

<img width="821" height="49" alt="1" src="https://github.com/user-attachments/assets/964b67bc-4a8d-4097-98f7-92baf6c999ac" />

To test the change create a custom exam with 5D problem and fail it by timeout

<img width="661" height="494" alt="2" src="https://github.com/user-attachments/assets/4528f5f3-e223-4837-8aa0-2dcfbad96f55" />

Now you can see it appear on "my mistakes" page and stats.

<img width="825" height="60" alt="3" src="https://github.com/user-attachments/assets/6ab5fe91-d74f-46ab-894c-eb81c6e226b0" />

<img width="1010" height="188" alt="4" src="https://github.com/user-attachments/assets/973e7004-b97d-4986-9b2f-2546ce856e69" />


