### PR TITLE
OGS HttpClient API: require explicit path

### DIFF
--- a/lib/game_client/ogs/http_client.dart
+++ b/lib/game_client/ogs/http_client.dart
@@ -8,38 +8,27 @@ import 'package:http/http.dart' as http;
 /// - Server URL management
 /// - CSRF token handling
 /// - Common headers
-/// - API versioning
 /// - JSON encoding/decoding
 ///
-/// TODO: Refactor this interface to be more ergonomic,
-/// similar to OGS's requests.ts implementation:
-/// https://github.com/online-go/online-go.com/blob/f80f1f612d971c96dcea4c79b4478c9069f3ad6e/src/lib/requests.ts
 class HttpClient {
   static const String _userAgent = 'WeiqiHub/1.0';
 
   final String serverUrl;
   final http.Client _httpClient;
-  final int? defaultApiVersion;
 
   String? csrfToken;
 
   HttpClient({
     required this.serverUrl,
     http.Client? httpClient,
-    this.defaultApiVersion = 1,
   }) : _httpClient = httpClient ?? http.Client();
 
   /// Makes a GET request and returns the parsed JSON response
   Future<Map<String, dynamic>> getJson(
     String path, {
     Map<String, String>? queryParameters,
-    int? apiVersion,
-    bool useApiPrefix = true,
   }) async {
-    final response = await _get(path,
-        queryParameters: queryParameters,
-        apiVersion: apiVersion,
-        useApiPrefix: useApiPrefix);
+    final response = await _get(path, queryParameters: queryParameters);
     return jsonDecode(response.body) as Map<String, dynamic>;
   }
 
@@ -47,13 +36,8 @@ class HttpClient {
   Future<String> getText(
     String path, {
     Map<String, String>? queryParameters,
-    int? apiVersion,
-    bool useApiPrefix = true,
   }) async {
-    final response = await _get(path,
-        queryParameters: queryParameters,
-        apiVersion: apiVersion,
-        useApiPrefix: useApiPrefix);
+    final response = await _get(path, queryParameters: queryParameters);
     return response.body;
   }
 
@@ -61,10 +45,8 @@ class HttpClient {
   Future<http.Response> _get(
     String path, {
     Map<String, String>? queryParameters,
-    int? apiVersion,
-    bool useApiPrefix = true,
   }) async {
-    final uri = _buildUri(path, queryParameters, apiVersion, useApiPrefix);
+    final uri = _buildUri(path, queryParameters);
 
     final response = await _httpClient.get(
       uri,
@@ -80,10 +62,8 @@ class HttpClient {
     String path,
     Map<String, dynamic> data, {
     Map<String, String>? queryParameters,
-    int? apiVersion,
   }) async {
-    final response = await _post(path, data,
-        queryParameters: queryParameters, apiVersion: apiVersion);
+    final response = await _post(path, data, queryParameters: queryParameters);
     return jsonDecode(response.body) as Map<String, dynamic>;
   }
 
@@ -92,9 +72,8 @@ class HttpClient {
     String path,
     Map<String, dynamic> data, {
     Map<String, String>? queryParameters,
-    int? apiVersion,
   }) async {
-    final uri = _buildUri(path, queryParameters, apiVersion);
+    final uri = _buildUri(path, queryParameters);
 
     final response = await _httpClient.post(
       uri,
@@ -111,21 +90,17 @@ class HttpClient {
     String path,
     Map<String, dynamic> data, {
     Map<String, String>? queryParameters,
-    int? apiVersion,
   }) async {
-    final response = await _put(path, data,
-        queryParameters: queryParameters, apiVersion: apiVersion);
+    final response = await _put(path, data, queryParameters: queryParameters);
     return jsonDecode(response.body) as Map<String, dynamic>;
   }
 
-  /// Makes a PUT request with JSON payload and returns the raw HTTP response
   Future<http.Response> _put(
     String path,
     Map<String, dynamic> data, {
     Map<String, String>? queryParameters,
-    int? apiVersion,
   }) async {
-    final uri = _buildUri(path, queryParameters, apiVersion);
+    final uri = _buildUri(path, queryParameters);
 
     final response = await _httpClient.put(
       uri,
@@ -137,24 +112,8 @@ class HttpClient {
     return response;
   }
 
-  /// Builds the complete URI for a given path and query parameters
-  Uri _buildUri(
-      String path, Map<String, String>? queryParameters, int? apiVersion,
-      [bool useApiPrefix = true]) {
-    // Use provided apiVersion, or default, or none
-    final version = apiVersion ?? defaultApiVersion;
-
-    String fullPath;
-    if (!useApiPrefix) {
-      // Direct path without /api prefix (e.g., for termination-api)
-      fullPath = '$serverUrl$path';
-    } else {
-      fullPath = version != null
-          ? '$serverUrl/api/v$version$path'
-          : '$serverUrl/api$path';
-    }
-
-    final uri = Uri.parse(fullPath);
+  Uri _buildUri(String path, Map<String, String>? queryParameters) {
+    final uri = Uri.parse('$serverUrl$path');
 
     if (queryParameters != null && queryParameters.isNotEmpty) {
       return uri.replace(queryParameters: queryParameters);

--- a/lib/game_client/ogs/ogs_game.dart
+++ b/lib/game_client/ogs/ogs_game.dart
@@ -64,8 +64,7 @@ class OGSGame extends Game {
   })  : _webSocketManager = webSocketManager,
         _myUserId = myUserId,
         _jwtToken = jwtToken,
-        _aiHttpClient =
-            HttpClient(serverUrl: aiServerUrl, defaultApiVersion: null),
+        _aiHttpClient = HttpClient(serverUrl: aiServerUrl),
         _freeHandicapPlacement = freeHandicapPlacement {
     _logger.info('Initialized OGSGame with id: $id');
     _moveController = StreamController<wq.Move?>.broadcast();
@@ -650,7 +649,7 @@ class OGSGame extends Game {
     };
 
     try {
-      final responseData = await _aiHttpClient.postJson('/score', payload);
+      final responseData = await _aiHttpClient.postJson('/api/score', payload);
       _logger.fine('AI server response received for game $id');
       return responseData;
     } catch (e) {

--- a/lib/game_client/ogs/ogs_game_client.dart
+++ b/lib/game_client/ogs/ogs_game_client.dart
@@ -44,7 +44,7 @@ class OGSGameClient extends GameClient {
   late final OGSWebSocketManager _webSocketManager;
 
   OGSGameClient({required this.serverUrl, required this.aiServerUrl}) {
-    _httpClient = HttpClient(serverUrl: serverUrl, defaultApiVersion: 1);
+    _httpClient = HttpClient(serverUrl: serverUrl);
     _webSocketManager = OGSWebSocketManager(serverUrl: serverUrl);
 
     // Listen to WebSocket connection status
@@ -213,7 +213,6 @@ class OGSGameClient extends GameClient {
       final data = await _httpClient.getJson(
         '/termination-api/automatch-stats',
         queryParameters: {'ranks': ranksParam},
-        useApiPrefix: false,
       );
 
       final statsMap = <String, AutomatchPresetStats>{};
@@ -248,18 +247,18 @@ class OGSGameClient extends GameClient {
   Future<UserInfo> login(String username, String password) async {
     try {
       // First, get the CSRF token
-      final csrfData = await _httpClient.getJson('/ui/config');
+      final csrfData = await _httpClient.getJson('/api/v1/ui/config');
       final csrfToken = csrfData['csrf_token'] as String?;
       _httpClient.csrfToken = csrfToken;
 
       // Now attempt login
       final loginData = await _httpClient.postJson(
-          '/login',
-          {
-            'username': username,
-            'password': password,
-          },
-          apiVersion: 0);
+        '/api/v0/login',
+        {
+          'username': username,
+          'password': password,
+        },
+      );
 
       final userData = loginData['user'];
 
@@ -326,7 +325,7 @@ class OGSGameClient extends GameClient {
 
       // Query: all ongoing games where the user is a player and "time per move" is less than 1 hour
       final data = await _httpClient.getJson(
-        '/players/${userInfo.userId}/games/',
+        '/api/v1/players/${userInfo.userId}/games/',
         queryParameters: {
           'page_size': '10',
           'page': '1',
@@ -360,7 +359,7 @@ class OGSGameClient extends GameClient {
       throw Exception('Not logged in');
     }
 
-    final responseData = await _httpClient.getJson('/games/$gameId');
+    final responseData = await _httpClient.getJson('/api/v1/games/$gameId');
     final gameData = responseData['gamedata'] as Map<String, dynamic>;
 
     // Parse game information
@@ -507,7 +506,7 @@ class OGSGameClient extends GameClient {
       }
 
       final data = await _httpClient.getJson(
-        '/players/${userInfo.userId}/games/',
+        '/api/v1/players/${userInfo.userId}/games/',
         queryParameters: {
           'page_size': '50',
           'page': '1',
@@ -593,7 +592,7 @@ class OGSGameClient extends GameClient {
   @override
   Future<GameRecord> getGame(String gameId) async {
     try {
-      final sgfContent = await _httpClient.getText('/games/$gameId/sgf');
+      final sgfContent = await _httpClient.getText('/api/v1/games/$gameId/sgf');
       return GameRecord.fromSgf(sgfContent);
     } catch (e) {
       throw Exception('Failed to get game record: $e');

--- a/test/http_client_test.dart
+++ b/test/http_client_test.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:wqhub/game_client/ogs/http_client.dart';
+
+void main() {
+  const serverUrl = 'https://online-go.com';
+
+  group('HttpClient', () {
+    test('builds URL from serverUrl + path', () async {
+      Uri? capturedUri;
+      final mockClient = MockClient((request) async {
+        capturedUri = request.url;
+        return http.Response('{}', 200);
+      });
+
+      final client = HttpClient(serverUrl: serverUrl, httpClient: mockClient);
+      await client.getJson('/api/v1/games/123');
+
+      expect(capturedUri.toString(), '$serverUrl/api/v1/games/123');
+      client.dispose();
+    });
+
+    test('appends query parameters', () async {
+      Uri? capturedUri;
+      final mockClient = MockClient((request) async {
+        capturedUri = request.url;
+        return http.Response('{}', 200);
+      });
+
+      final client = HttpClient(serverUrl: serverUrl, httpClient: mockClient);
+      await client.getJson('/api/v1/games', queryParameters: {'page': '1'});
+
+      expect(capturedUri.toString(), '$serverUrl/api/v1/games?page=1');
+      client.dispose();
+    });
+
+    test('getJson returns parsed JSON', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('{"key": "value"}', 200);
+      });
+
+      final client = HttpClient(serverUrl: serverUrl, httpClient: mockClient);
+      expect(await client.getJson('/test'), {'key': 'value'});
+      client.dispose();
+    });
+
+    test('postJson sends JSON body', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, 'POST');
+        expect(jsonDecode(request.body), {'input': 'data'});
+        return http.Response('{"ok": true}', 200);
+      });
+
+      final client = HttpClient(serverUrl: serverUrl, httpClient: mockClient);
+      expect(await client.postJson('/test', {'input': 'data'}), {'ok': true});
+      client.dispose();
+    });
+
+    test('throws HttpStatusException on error status', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('Not Found', 404);
+      });
+
+      final client = HttpClient(serverUrl: serverUrl, httpClient: mockClient);
+      expect(
+        () => client.getJson('/test'),
+        throwsA(isA<HttpStatusException>()
+            .having((e) => e.statusCode, 'statusCode', 404)),
+      );
+      client.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

```
/// TODO: Refactor this interface to be more ergonomic,
/// similar to OGS's requests.ts implementation:
/// https://github.com/online-go/online-go.com/blob/f80f1f612d971c96dcea4c79b4478c9069f3ad6e/src/lib/requests.ts
```

Originally, this request TODO was about copying URL resolution from OGS source code. For example: "ui/config" -> "https://online-go.com/api/v1/ui/config"

But I ended up not liking it that much.  The reasoning being that our usage of the HTTP API covers a much smaller surface than the official client.  At the same time, the endpoints we *do* call are much more varied:

- `/api/v0/login`
- `/api/score`
- `/termination-api/automatch-stats`

So only about half of our HTTP calls would benefit from smart resolution.

Opting to make the API simpler by having the user send the full path when calling get/post etc. This should also make this class more portable if needed in non-OGS clients.

## Testing

- added new unit tests for `HttpClient`
- ran existing integration tests
- manually went through the app

    - login, logout
    - game history, opened a game
    - played a game to scoring (exercising the AI call)