### PR TITLE
Update range of endgame selection ranks

### DIFF
--- a/lib/train/endgame_exam_ranks.dart
+++ b/lib/train/endgame_exam_ranks.dart
@@ -1,16 +1,6 @@
 import 'package:wqhub/wq/rank.dart';
 
 const endgameExamRanks = [
-  Rank.k15,
-  Rank.k14,
-  Rank.k13,
-  Rank.k12,
-  Rank.k11,
-  Rank.k10,
-  Rank.k9,
-  Rank.k8,
-  Rank.k7,
-  Rank.k6,
   Rank.k5,
   Rank.k4,
   Rank.k3,
@@ -22,5 +12,4 @@ const endgameExamRanks = [
   Rank.d4,
   Rank.d5,
   Rank.d6,
-  Rank.d7,
 ];

--- a/lib/train/endgame_exam_selection_page.dart
+++ b/lib/train/endgame_exam_selection_page.dart
@@ -66,8 +66,8 @@ class _EndgameExamSelectionPageState
                   rankRange: RankRange.single(rank),
                   passCount: stats[rank]?.pass ?? 0,
                   failCount: stats[rank]?.fail ?? 0,
-                  isActive: (rank == Rank.k15) ||
-                      ((stats[Rank.values[max(Rank.k15.index, rank.index - 1)]]
+                  isActive: (rank == Rank.k5) ||
+                      ((stats[Rank.values[max(Rank.k5.index, rank.index - 1)]]
                                   ?.pass ??
                               0) >
                           0),


### PR DESCRIPTION
Due to the removal of many problems in the last release, there are not enough endgame problems for lower ranks. This change sets the range of endgame ranks to 5k -- 6d.

fixes #214