### PR TITLE
Build FOSS version of WeiqiHub for Linux

### DIFF
--- a/.github/workflows/build_linux_foss.yaml
+++ b/.github/workflows/build_linux_foss.yaml
@@ -14,8 +14,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh-private-key: ${{ secrets.READ_ONLY_PRIVATE_KEY }}
+          token: ${{ secrets.WQHUB_TOKEN }}
       - name: Install linux dependencies
         run: |
           sudo apt-get update -y

--- a/.github/workflows/build_linux_foss.yaml
+++ b/.github/workflows/build_linux_foss.yaml
@@ -1,0 +1,60 @@
+name: Build Linux FOSS (Production)
+permissions:
+  contents: write
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches: [ main ]
+jobs:
+  build-linux-foss:
+    name: "Build"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-private-key: ${{ secrets.READ_ONLY_PRIVATE_KEY }}
+      - name: Install linux dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get upgrade -y
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev libstdc++-12-dev
+          sudo apt-get install -y libasound2-dev
+          sudo apt-get install -y libfuse2
+      - name: Setup appimagetool
+        run: |
+          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /opt/appimagetool
+          cd /opt/; sudo chmod +x appimagetool; sed -i 's|AI\x02|\x00\x00\x00|' appimagetool; sudo ./appimagetool --appimage-extract
+          sudo mv /opt/squashfs-root /opt/appimagetool.AppDir
+          sudo ln -s /opt/appimagetool.AppDir/AppRun /usr/local/bin/appimagetool
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version-file: pubspec.yaml
+      - name: Install Flutter dependencies
+        run: flutter pub get
+      - name: Run tests
+        run: flutter test --exclude-tags=integration
+      - name: Build
+        env:
+          NO_OPUS_OGG_LIBS: 1
+        run: flutter build linux
+      - run: |
+          cp -a build/linux/x64/release/bundle/ z-linux-artifacts-foss-x86_64/
+          tar czf z-linux-artifacts-foss-x86_64.tar.gz z-linux-artifacts-foss-x86_64/
+      - name: Build AppImage
+        run: |
+          cp linux/appimage/AppRun build/linux/x64/release/bundle/
+          cp linux/appimage/com.walruswq.wqhub.desktop build/linux/x64/release/bundle/
+          cp linux/appimage/wqhub.png build/linux/x64/release/bundle/
+          appimagetool build/linux/x64/release/bundle WeiqiHub-linux-foss-x86_64.AppImage
+      - name: Release artifacts
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            *.AppImage
+            *.tar.gz

--- a/.github/workflows/build_linux_foss.yaml
+++ b/.github/workflows/build_linux_foss.yaml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.WQHUB_TOKEN }}
       - name: Install linux dependencies
         run: |
           sudo apt-get update -y


### PR DESCRIPTION
As discussed in #224, I added a new `build_linux_foss.yaml` GitHub Actions workflow based on the existing `build_linux.yaml`. It builds two files:

- WeiqiHub-linux-foss-x86_64.AppImage
- z-linux-artifacts-foss-x86_64.tar.gz

The latter contains a build archive for Flathub's build system. I chose to prefix the name with "z-" so it doesn't show up at the top of the list of released files.

I noticed that the `build_linux.yaml` file uploads artifacts, which I understand to be temporary files that can be used by other build processes. However they wren't showing up for me in my test private repo under Actions -> Cache, so I didn't add that code to this file. If that breaks your workflow in any way, let me know, and I can add it.

I also added code that will automatically upload the builds to the releases page when you push a tag for a new version. Feel free to adapt my code to your other build scripts.