### PR TITLE
Use consistent app naming for upstream, F-Droid

### DIFF
--- a/metadata/en-US/title.txt
+++ b/metadata/en-US/title.txt
@@ -1,1 +1,1 @@
-WeiqiHub (Libre)
+WeiqiHub


### PR DESCRIPTION
I think going with "WeiqiHub" on F-Droid makes the most sense, so I'd like to update that info here. Another reason for this change is that other systems like Google Play's upload console will read this metadata automatically, even if you can probably change it before uploading a new build there.