### PR TITLE
Upgrade Flutter for flutter_soloud depenency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ version: 0.1.14+41
 
 environment:
   sdk: ^3.6.0
-  flutter: 3.38.5
+  flutter: 3.41.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
This change is a starting point for fixing F-Droid builds of the flutter_soloud dependency (#232) , which uses

https://github.com/flutter/flutter/pull/176393

to support conditional inclusion of build artifacts according to the build target:

https://github.com/alnitak/flutter_soloud/blob/main/pubspec.yaml#L72

An alternative may be to downgrade `flutter_soloud`, which may or may not work out.

If you test this patch, you'll also need to update the `pubspec.lock` file. It looks like there are a few listed above the [error message](https://gitlab.com/leaf-node/fdroiddata/-/jobs/15300797144#L663) in the CI job, but those four are sub-dependencies. I don't know if there is a way to selectively upgrade the lock file... Perhaps doing as suggested: running run `flutter pub get` without `--enforce-lockfile`, then commit the result. I suspect that keeping the same versions of packages in pubspec.yaml may allow you to upgrade the lock file a little bit without breaking too much compatibility with otherwise working dependencies.